### PR TITLE
Feat: Updating default.json to have at least one merge field

### DIFF
--- a/src/routes/default.json
+++ b/src/routes/default.json
@@ -1,4 +1,10 @@
 {
+    "merge": [
+        {
+            "find": "NAME",
+            "replace": "world"
+        }
+    ],
     "timeline": {
         "tracks": [
             {


### PR DESCRIPTION
Default JSON needs to have at least one merge field to show and demonstrate appropriate working behaviour