### PR TITLE
Template validation and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .env
 .env.*
 !.env.example
+coverage

--- a/src/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -30,15 +30,51 @@ describe('ShotstackEditTemplateService.setTemplateSource', () => {
 		editTemplateService.setTemplateSource('{ "merge": [ { "find": "test", "replace": "foo" } ] }');
 
 		expect(editTemplateService.template.merge).toEqual([{ find: 'test', replace: 'foo' }]);
+
+
 	});
 
 	test('Throws error if not merge array passed', () => {
 		const editTemplateService = new ShotstackEditTemplateService();
-
+		expect(() => editTemplateService.setTemplateSource("<>")).toThrowError(INVALID_JSON)
 		expect(() => editTemplateService.setTemplateSource('{}')).toThrowError(MERGE_NOT_FOUND);
 	});
 });
 
+describe("ShotstackEditTemplateService.castIntoType", () => {
+	test('Correctly casts an element into a JSON valid type, or else returns a string', () => {
+		let service = new ShotstackEditTemplateService()
+
+		let number = service.castIntoType('1234')
+		expect(number).toEqual(1234)
+
+		let bFalse = service.castIntoType('false')
+		expect(bFalse).toEqual(false)
+
+		let bTrue = service.castIntoType('true')
+		expect(bTrue).toEqual(true)
+
+		let bNull = service.castIntoType('null')
+		expect(bNull).toEqual(null)
+
+		let string = service.castIntoType("A normal string")
+		expect(string).toEqual("A normal string")
+
+		let map = service.castIntoType(JSON.stringify({ foo: "bar" }))
+		expect(map).toEqual({ foo: "bar" })
+
+		let array = service.castIntoType(JSON.stringify(["1", 2, 3]))
+		expect(array).toEqual(["1", 2, 3])
+	})
+	test("Every invalid JSON type should return a string", () => {
+		let service = new ShotstackEditTemplateService()
+		let fn = service.castIntoType("function(){}")
+		expect(fn).toEqual("function(){}")
+
+		let und = service.castIntoType('undefined')
+		expect(und).toEqual('undefined')
+	})
+})
 describe('ShotstackEditTemplateService.updateResultMergeFields', () => {
 	test('Correctly updates the resulting merge array', () => {
 		const editTemplateService = new ShotstackEditTemplateService({

--- a/src/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, test } from '@jest/globals';
+import { INVALID_JSON, MERGE_NOT_FOUND } from './constants';
 
 import { ShotstackEditTemplateService } from './ShotstackEditTemplateService';
 
@@ -34,14 +35,12 @@ describe('ShotstackEditTemplateService.setTemplateSource', () => {
 	test('Throws error if not merge array passed', () => {
 		const editTemplateService = new ShotstackEditTemplateService();
 
-		expect(() => editTemplateService.setTemplateSource('{}')).toThrowError(
-			'No merge fields array was found'
-		);
+		expect(() => editTemplateService.setTemplateSource('{}')).toThrowError(MERGE_NOT_FOUND);
 	});
 });
 
 describe('ShotstackEditTemplateService.updateResultMergeFields', () => {
-	test('Correctly updates the result merge array', () => {
+	test('Correctly updates the resulting merge array', () => {
 		const editTemplateService = new ShotstackEditTemplateService({
 			merge: [
 				{

--- a/src/ShotstackEditTemplate/constants.ts
+++ b/src/ShotstackEditTemplate/constants.ts
@@ -1,0 +1,8 @@
+export const INVALID_JSON = /^Unexpected token . in JSON at position .+$/
+export const MERGE_NOT_FOUND = "A 'merge' property is required"
+export const MERGE_MUST_BE_ARRAY = "Property 'merge' must be an array"
+export const MERGE_NOT_EMPTY = "Property 'merge' must contain at least one element"
+export const FIND_NOT_FOUND = `A 'find' property is required on every element inside 'merge'`
+export const FIND_MUST_BE_STRING = `Every 'find' property inside 'merge' must be of type string`
+export const FIND_NOT_EMPTY = `Every 'find' property inside 'merge' must be a string of length equal to or higher than one`
+export const REPLACE_NOT_FOUND = `A 'replace' property is required on every element inside 'merge'`

--- a/src/ShotstackEditTemplate/constants.ts
+++ b/src/ShotstackEditTemplate/constants.ts
@@ -1,8 +1,8 @@
 export const INVALID_JSON = /^Unexpected token . in JSON at position .+$/
 export const MERGE_NOT_FOUND = "A 'merge' property is required"
-export const MERGE_MUST_BE_ARRAY = "Property 'merge' must be an array"
+export const MERGE_NOT_ARRAY = "Property 'merge' must be an array"
 export const MERGE_NOT_EMPTY = "Property 'merge' must contain at least one element"
 export const FIND_NOT_FOUND = `A 'find' property is required on every element inside 'merge'`
-export const FIND_MUST_BE_STRING = `Every 'find' property inside 'merge' must be of type string`
+export const FIND_NOT_STRING = `Every 'find' property inside 'merge' must be of type string`
 export const FIND_NOT_EMPTY = `Every 'find' property inside 'merge' must be a string of length equal to or higher than one`
 export const REPLACE_NOT_FOUND = `A 'replace' property is required on every element inside 'merge'`

--- a/src/ShotstackEditTemplate/types.ts
+++ b/src/ShotstackEditTemplate/types.ts
@@ -1,0 +1,15 @@
+export type JSONValidTypes = string | number | boolean | null | JSONValidTypes[]| JSONLikeObject
+
+export interface JSONLikeObject {
+	[key: string]: JSONValidTypes
+}
+
+export interface MergeField {
+	find: string;
+	replace: JSONValidTypes;
+}
+
+export interface IParsedEditSchema {
+	merge: MergeField[];
+	[key: string]: any;
+}

--- a/src/ShotstackEditTemplate/validate.test.ts
+++ b/src/ShotstackEditTemplate/validate.test.ts
@@ -1,0 +1,21 @@
+import defaultJSON from '../routes/default.json'
+import { INVALID_JSON, MERGE_NOT_FOUND } from './constants'
+import { validateTemplate, ValidationError } from './validate'
+describe("ShotstackEditTemplate/validate.ts", () => {
+    test("If valid stringified json is passed, it should return a valid json", () => {
+        let validStringified = JSON.stringify(defaultJSON)
+        let result = validateTemplate(validStringified)
+        expect(result).toEqual(defaultJSON)
+    })
+    test("If input is an invalid json, it should throw an error", () => {
+        let invalidJson = "<invalid>"
+        expect(() => validateTemplate(invalidJson)).toThrowError(INVALID_JSON)
+    })
+
+    test("If input does not have a merge property, it should throw", () => {
+        let noMerge = JSON.stringify({ foo: "bar" })
+        expect(() => validateTemplate(noMerge)).toThrowError(MERGE_NOT_FOUND)
+    })
+
+})
+

--- a/src/ShotstackEditTemplate/validate.test.ts
+++ b/src/ShotstackEditTemplate/validate.test.ts
@@ -1,5 +1,5 @@
 import defaultJSON from '../routes/default.json'
-import { INVALID_JSON, MERGE_NOT_FOUND } from './constants'
+import { FIND_NOT_EMPTY, FIND_NOT_FOUND, FIND_NOT_STRING, INVALID_JSON, MERGE_NOT_ARRAY, MERGE_NOT_EMPTY, MERGE_NOT_FOUND, REPLACE_NOT_FOUND } from './constants'
 import { validateTemplate, ValidationError } from './validate'
 describe("ShotstackEditTemplate/validate.ts", () => {
     test("If valid stringified json is passed, it should return a valid json", () => {
@@ -7,15 +7,44 @@ describe("ShotstackEditTemplate/validate.ts", () => {
         let result = validateTemplate(validStringified)
         expect(result).toEqual(defaultJSON)
     })
-    test("If input is an invalid json, it should throw an error", () => {
+    test("Should throw an error if input is an invalid json", () => {
         let invalidJson = "<invalid>"
         expect(() => validateTemplate(invalidJson)).toThrowError(INVALID_JSON)
     })
 
-    test("If input does not have a merge property, it should throw", () => {
+    test("Should throw if input does not have a merge property, ", () => {
         let noMerge = JSON.stringify({ foo: "bar" })
         expect(() => validateTemplate(noMerge)).toThrowError(MERGE_NOT_FOUND)
     })
 
+    test("Should throw if merge is not an array", () => {
+        let noArray = JSON.stringify({ merge: { foo: "bar" } })
+        expect(() => validateTemplate(noArray)).toThrowError(MERGE_NOT_ARRAY)
+    })
+
+    test("Should throw if merge is empty", () => {
+        let emptyArray = JSON.stringify({ merge: [] })
+        expect(() => validateTemplate(emptyArray)).toThrowError(MERGE_NOT_EMPTY)
+    })
+
+    test("Should throw if a merge item doesn't have the find prop", () => {
+        let noFind = JSON.stringify({ merge: [{ find: "foo", replace: "bar" }, {}] })
+        expect(() => validateTemplate(noFind)).toThrowError(FIND_NOT_FOUND)
+    })
+
+    test("Should throw if a merge item doesn't have the replace prop", () => {
+        let noFind = JSON.stringify({ merge: [{ find: "foo" }] })
+        expect(() => validateTemplate(noFind)).toThrowError(REPLACE_NOT_FOUND)
+    })
+
+    test("Should throw if find prop is not a string", () => {
+        let notString = JSON.stringify({ merge: [{ find: 123, replace: "bar" }] })
+        expect(() => validateTemplate(notString)).toThrowError(FIND_NOT_STRING)
+    })
+
+    test("Should throw if find prop is an empty string", () => {
+        let notString = JSON.stringify({ merge: [{ find: "", replace: "bar" }] })
+        expect(() => validateTemplate(notString)).toThrowError(FIND_NOT_EMPTY)
+    })
 })
 

--- a/src/ShotstackEditTemplate/validate.ts
+++ b/src/ShotstackEditTemplate/validate.ts
@@ -1,0 +1,46 @@
+import type { IParsedEditSchema } from "./types"
+
+export class ValidationError extends Error {
+    constructor(message: string) {
+        super(message)
+    }
+}
+
+function propertyDoesNotExist(prop: string, json: any) {
+    return json[prop] === undefined
+}
+
+function isNotInstanceOfArray(prop: string, json: any) {
+    return !(json[prop] instanceof Array)
+}
+
+function isNotString(prop: string, json: any) {
+    return !(typeof json[prop] === 'string')
+}
+
+function isEmptyString(prop: string, json: any) {
+    return !(typeof json[prop] === 'string' && json[prop].length > 0)
+}
+function isEmptyArray(prop: string, json: any) {
+    return !(json[prop] instanceof Array && json[prop].length > 0)
+}
+export function validateTemplate(jsonTemplate: string): IParsedEditSchema {
+    try {
+        let parsed = JSON.parse(jsonTemplate)
+        if (propertyDoesNotExist("merge", parsed)) throw new ValidationError("A 'merge' property is required")
+        if (isNotInstanceOfArray("merge", parsed)) throw new ValidationError("Property 'merge' must be an array")
+        if (isEmptyArray('merge', parsed)) throw new ValidationError("Property 'merge' must contain at least one element")
+        parsed.merge.forEach((field: any, index: number) => {
+            if (propertyDoesNotExist("find", field)) throw new ValidationError(`Missing property 'find' at index ${index}`)
+            if (propertyDoesNotExist("replace", field)) throw new ValidationError(`Missing property 'replace' at index ${index}`)
+            if (isNotString("find", field)) throw new ValidationError(`Property 'find' at index ${index} must be a string`)
+            if (isEmptyString('find', field)) throw new ValidationError(`Value of property 'find' at index ${index} must not be empty`)
+        })
+        return parsed as IParsedEditSchema
+    }
+    catch (error) {
+        if (error instanceof ValidationError) throw error
+        else if (error.message) throw error
+        else throw new ValidationError('There was a problem parsing the template json')
+    }
+}

--- a/src/ShotstackEditTemplate/validate.ts
+++ b/src/ShotstackEditTemplate/validate.ts
@@ -1,3 +1,4 @@
+import { FIND_MUST_BE_STRING, FIND_NOT_EMPTY, FIND_NOT_FOUND, MERGE_MUST_BE_ARRAY, MERGE_NOT_EMPTY, MERGE_NOT_FOUND, REPLACE_NOT_FOUND } from "./constants"
 import type { IParsedEditSchema } from "./types"
 
 export class ValidationError extends Error {
@@ -27,14 +28,14 @@ function isEmptyArray(prop: string, json: any) {
 export function validateTemplate(jsonTemplate: string): IParsedEditSchema {
     try {
         let parsed = JSON.parse(jsonTemplate)
-        if (propertyDoesNotExist("merge", parsed)) throw new ValidationError("A 'merge' property is required")
-        if (isNotInstanceOfArray("merge", parsed)) throw new ValidationError("Property 'merge' must be an array")
-        if (isEmptyArray('merge', parsed)) throw new ValidationError("Property 'merge' must contain at least one element")
+        if (propertyDoesNotExist("merge", parsed)) throw new ValidationError(MERGE_NOT_FOUND)
+        if (isNotInstanceOfArray("merge", parsed)) throw new ValidationError(MERGE_MUST_BE_ARRAY)
+        if (isEmptyArray('merge', parsed)) throw new ValidationError(MERGE_NOT_EMPTY)
         parsed.merge.forEach((field: any, index: number) => {
-            if (propertyDoesNotExist("find", field)) throw new ValidationError(`Missing property 'find' at index ${index}`)
-            if (propertyDoesNotExist("replace", field)) throw new ValidationError(`Missing property 'replace' at index ${index}`)
-            if (isNotString("find", field)) throw new ValidationError(`Property 'find' at index ${index} must be a string`)
-            if (isEmptyString('find', field)) throw new ValidationError(`Value of property 'find' at index ${index} must not be empty`)
+            if (propertyDoesNotExist("find", field)) throw new ValidationError(FIND_NOT_FOUND)
+            if (propertyDoesNotExist("replace", field)) throw new ValidationError(REPLACE_NOT_FOUND)
+            if (isNotString("find", field)) throw new ValidationError(FIND_MUST_BE_STRING)
+            if (isEmptyString('find', field)) throw new ValidationError(FIND_NOT_EMPTY)
         })
         return parsed as IParsedEditSchema
     }

--- a/src/ShotstackEditTemplate/validate.ts
+++ b/src/ShotstackEditTemplate/validate.ts
@@ -1,4 +1,4 @@
-import { FIND_MUST_BE_STRING, FIND_NOT_EMPTY, FIND_NOT_FOUND, MERGE_MUST_BE_ARRAY, MERGE_NOT_EMPTY, MERGE_NOT_FOUND, REPLACE_NOT_FOUND } from "./constants"
+import { FIND_NOT_STRING, FIND_NOT_EMPTY, FIND_NOT_FOUND, MERGE_NOT_ARRAY, MERGE_NOT_EMPTY, MERGE_NOT_FOUND, REPLACE_NOT_FOUND } from "./constants"
 import type { IParsedEditSchema } from "./types"
 
 export class ValidationError extends Error {
@@ -29,12 +29,12 @@ export function validateTemplate(jsonTemplate: string): IParsedEditSchema {
     try {
         let parsed = JSON.parse(jsonTemplate)
         if (propertyDoesNotExist("merge", parsed)) throw new ValidationError(MERGE_NOT_FOUND)
-        if (isNotInstanceOfArray("merge", parsed)) throw new ValidationError(MERGE_MUST_BE_ARRAY)
+        if (isNotInstanceOfArray("merge", parsed)) throw new ValidationError(MERGE_NOT_ARRAY)
         if (isEmptyArray('merge', parsed)) throw new ValidationError(MERGE_NOT_EMPTY)
         parsed.merge.forEach((field: any, index: number) => {
             if (propertyDoesNotExist("find", field)) throw new ValidationError(FIND_NOT_FOUND)
             if (propertyDoesNotExist("replace", field)) throw new ValidationError(REPLACE_NOT_FOUND)
-            if (isNotString("find", field)) throw new ValidationError(FIND_MUST_BE_STRING)
+            if (isNotString("find", field)) throw new ValidationError(FIND_NOT_STRING)
             if (isEmptyString('find', field)) throw new ValidationError(FIND_NOT_EMPTY)
         })
         return parsed as IParsedEditSchema

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import '../app.css';
 	import { ShotstackEditTemplateService } from '../ShotstackEditTemplate/ShotstackEditTemplateService';
-	import type { MergeField } from '../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './default.json';
 
 	// DEFAULT JSON VALUE PLACEHOLDER TO JSON TEXTAREA INPUT


### PR DESCRIPTION
# Summary 
- Validates an input and returns a verified merge schema (hard coded, pending schema)
- Adds tests for validation method and use cases
- Adding separation of concerns when handling inputs, split into validation and state setting
- Adds constants for error messages for testing and avoiding magic strings

# Evidence
Unit test
![image](https://user-images.githubusercontent.com/55909151/191625164-045b29bc-c78d-4561-ab66-9c62742b6b80.png)

e2e test
![image](https://user-images.githubusercontent.com/55909151/191625572-8cbfcc02-b2c2-4811-b429-872865116857.png)

