### PR TITLE
Validate merge

### DIFF
--- a/src/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -41,40 +41,6 @@ describe('ShotstackEditTemplateService.setTemplateSource', () => {
 	});
 });
 
-describe("ShotstackEditTemplateService.castIntoType", () => {
-	test('Correctly casts an element into a JSON valid type, or else returns a string', () => {
-		let service = new ShotstackEditTemplateService()
-
-		let number = service.castIntoType('1234')
-		expect(number).toEqual(1234)
-
-		let bFalse = service.castIntoType('false')
-		expect(bFalse).toEqual(false)
-
-		let bTrue = service.castIntoType('true')
-		expect(bTrue).toEqual(true)
-
-		let bNull = service.castIntoType('null')
-		expect(bNull).toEqual(null)
-
-		let string = service.castIntoType("A normal string")
-		expect(string).toEqual("A normal string")
-
-		let map = service.castIntoType(JSON.stringify({ foo: "bar" }))
-		expect(map).toEqual({ foo: "bar" })
-
-		let array = service.castIntoType(JSON.stringify(["1", 2, 3]))
-		expect(array).toEqual(["1", 2, 3])
-	})
-	test("Every invalid JSON type should return a string", () => {
-		let service = new ShotstackEditTemplateService()
-		let fn = service.castIntoType("function(){}")
-		expect(fn).toEqual("function(){}")
-
-		let und = service.castIntoType('undefined')
-		expect(und).toEqual('undefined')
-	})
-})
 describe('ShotstackEditTemplateService.updateResultMergeFields', () => {
 	test('Correctly updates the resulting merge array', () => {
 		const editTemplateService = new ShotstackEditTemplateService({

--- a/src/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -1,4 +1,4 @@
-import type { IParsedEditSchema, JSONValidTypes, MergeField } from './types'
+import type { IParsedEditSchema, MergeField } from './types'
 import { validateTemplate } from './validate';
 
 export class ShotstackEditTemplateService {
@@ -22,20 +22,9 @@ export class ShotstackEditTemplateService {
 		}
 	}
 
-	castIntoType(input: string): JSONValidTypes {
-		if (!isNaN(Number(input)) && input.length > 0) return Number(input)
-		try {
-			let parsed = JSON.parse(input);
-			return parsed
-		}
-		catch (error) {
-			return input;
-		}
-	}
-
 	updateResultMergeFields(mergeFieldInput: { find: string, replace: string }) {
 		const { find, replace } = mergeFieldInput;
-		const validMergeField: MergeField = { find, replace: this.castIntoType(replace) };
+		const validMergeField: MergeField = {find, replace};
 		const merge = this.result.merge.map((mergeField) =>
 			mergeField?.find === mergeFieldInput.find ? validMergeField : mergeField
 		);

--- a/src/ShotstackEditTemplate/validate.test.ts
+++ b/src/ShotstackEditTemplate/validate.test.ts
@@ -1,50 +1,59 @@
 import defaultJSON from '../routes/default.json'
 import { FIND_NOT_EMPTY, FIND_NOT_FOUND, FIND_NOT_STRING, INVALID_JSON, MERGE_NOT_ARRAY, MERGE_NOT_EMPTY, MERGE_NOT_FOUND, REPLACE_NOT_FOUND } from './constants'
-import { validateTemplate, ValidationError } from './validate'
+import { validateTemplate, ValidationError, validateMerge } from './validate'
 describe("ShotstackEditTemplate/validate.ts", () => {
     test("If valid stringified json is passed, it should return a valid json", () => {
-        let validStringified = JSON.stringify(defaultJSON)
-        let result = validateTemplate(validStringified)
+        const validStringified = JSON.stringify(defaultJSON)
+        const result = validateTemplate(validStringified)
         expect(result).toEqual(defaultJSON)
     })
     test("Should throw an error if input is an invalid json", () => {
-        let invalidJson = "<invalid>"
+        const invalidJson = "<invalid>"
         expect(() => validateTemplate(invalidJson)).toThrowError(INVALID_JSON)
     })
 
     test("Should throw if input does not have a merge property, ", () => {
-        let noMerge = JSON.stringify({ foo: "bar" })
+        const noMerge = JSON.stringify({ foo: "bar" })
         expect(() => validateTemplate(noMerge)).toThrowError(MERGE_NOT_FOUND)
     })
 
     test("Should throw if merge is not an array", () => {
-        let noArray = JSON.stringify({ merge: { foo: "bar" } })
+        const noArray = JSON.stringify({ merge: { foo: "bar" } })
         expect(() => validateTemplate(noArray)).toThrowError(MERGE_NOT_ARRAY)
     })
 
     test("Should throw if merge is empty", () => {
-        let emptyArray = JSON.stringify({ merge: [] })
+        const emptyArray = JSON.stringify({ merge: [] })
         expect(() => validateTemplate(emptyArray)).toThrowError(MERGE_NOT_EMPTY)
-    })
-
-    test("Should throw if a merge item doesn't have the find prop", () => {
-        let noFind = JSON.stringify({ merge: [{ find: "foo", replace: "bar" }, {}] })
-        expect(() => validateTemplate(noFind)).toThrowError(FIND_NOT_FOUND)
-    })
-
-    test("Should throw if a merge item doesn't have the replace prop", () => {
-        let noFind = JSON.stringify({ merge: [{ find: "foo" }] })
-        expect(() => validateTemplate(noFind)).toThrowError(REPLACE_NOT_FOUND)
-    })
-
-    test("Should throw if find prop is not a string", () => {
-        let notString = JSON.stringify({ merge: [{ find: 123, replace: "bar" }] })
-        expect(() => validateTemplate(notString)).toThrowError(FIND_NOT_STRING)
-    })
-
-    test("Should throw if find prop is an empty string", () => {
-        let notString = JSON.stringify({ merge: [{ find: "", replace: "bar" }] })
-        expect(() => validateTemplate(notString)).toThrowError(FIND_NOT_EMPTY)
     })
 })
 
+describe("ShotstackEditTemplate/validate.ts .validateMerge", () =>{
+    test("Should throw if a merge item doesn't have the find prop", () =>{
+        const mergeNotFound = [{foo: "bar", replace: "bar"}]
+        expect( () => validateMerge(mergeNotFound)).toThrowError(FIND_NOT_FOUND)
+    })
+    test("Should throw if a merge item doesn't have the replace prop", () =>{
+        const replaceNotFound = [{find: "foo", bar: "bar"}]
+        expect( () => validateMerge(replaceNotFound)).toThrowError(REPLACE_NOT_FOUND)
+    })
+    test("Should throw if find prop is not a string", () =>{
+        const findNotString = [{find: 1, replace: "bar"}]
+        expect( () => validateMerge(findNotString)).toThrowError(FIND_NOT_STRING)
+    })
+    test("Should throw if find prop is an empty string", () =>{
+        const findEmpty = [{find:"", replace:"bar"}]
+        expect(()=> validateMerge(findEmpty)).toThrowError(FIND_NOT_EMPTY)
+    })
+    test("The value of the replace prop should always be a string when it receives a non string value", () =>{
+        const replaceIsString = [{find:"bar", replace: null}]
+        const result = validateMerge(replaceIsString)
+        expect(result).toStrictEqual([{find:"bar", replace: "null"}])
+    })
+
+    test("The value of find and replace props on a merge item should always be a string",  () =>{
+        const isAlwaysString = [{find:"bar", replace: "foo"}]
+        const result = validateMerge(isAlwaysString)
+        expect(result).toStrictEqual([{find:"bar", replace: "foo"}])
+    })
+})


### PR DESCRIPTION
As requested, the find and replace values on a merge field should always be a string, independent of the value it receives. A new function validateMerge is added to ensure that the validation of provided templates follow this rule.