### PR TITLE
Feat: Adding svelte testing library to test rendered DOM elements

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,8 +2,13 @@ import type { Config } from 'jest';
 import { defaults } from 'jest-config';
 
 const config: Config = {
-	moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts'],
-	testEnvironment: 'jsdom'
+	moduleFileExtensions: ['js', 'ts', 'svelte'],
+	testEnvironment: 'jsdom',
+	transform: {
+		'^.+\\.js$': 'babel-jest',
+		'^.+\\.ts$': 'ts-jest',
+		'^.+\\.svelte$': ['svelte-jester', { preprocess: true }]
+	}
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@sveltejs/adapter-auto": "next",
 				"@sveltejs/adapter-static": "^1.0.0-next.43",
 				"@sveltejs/kit": "next",
+				"@testing-library/svelte": "^3.2.1",
 				"@types/jest": "^29.0.3",
 				"@typescript-eslint/eslint-plugin": "^5.27.0",
 				"@typescript-eslint/parser": "^5.27.0",
@@ -31,8 +32,10 @@
 				"prettier-plugin-svelte": "^2.7.0",
 				"svelte": "^3.44.0",
 				"svelte-check": "^2.7.1",
+				"svelte-jester": "^2.3.2",
 				"svelte-preprocess": "^4.10.7",
 				"tailwindcss": "^3.1.8",
+				"ts-jest": "^29.0.2",
 				"tslib": "^2.3.1",
 				"typescript": "^4.7.4",
 				"vite": "^3.1.0"
@@ -2731,6 +2734,72 @@
 				}
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.18.1.tgz",
+			"integrity": "sha512-oEvsm2B/WtcHKE+IcEeeCqNU/ltFGaVyGbpcm4g/2ytuT49jrlH9x5qRKL/H3A6yfM4YAbSbC0ceT5+9CEXnLg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^5.0.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.4.4",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true
+		},
+		"node_modules/@testing-library/svelte": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-3.2.1.tgz",
+			"integrity": "sha512-qP5nMAx78zt+a3y9Sws9BNQYP30cOQ/LXDYuAj7wNtw86b7AtB7TFAz6/Av9hFsW3IJHPBBIGff6utVNyq+F1g==",
+			"dev": true,
+			"dependencies": {
+				"@testing-library/dom": "^8.1.0"
+			},
+			"engines": {
+				"node": ">= 10"
+			},
+			"peerDependencies": {
+				"svelte": "3.x"
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2771,6 +2840,12 @@
 			"dev": true,
 			"optional": true,
 			"peer": true
+		},
+		"node_modules/@types/aria-query": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+			"dev": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.1.19",
@@ -3414,6 +3489,15 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/aria-query": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.2.tgz",
+			"integrity": "sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0"
+			}
+		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -3792,6 +3876,18 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"dependencies": {
+				"fast-json-stable-stringify": "2.x"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/bser": {
@@ -4648,6 +4744,12 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.14",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+			"dev": true
 		},
 		"node_modules/domexception": {
 			"version": "4.0.0",
@@ -7471,6 +7573,12 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7560,6 +7668,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/lz-string": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"dev": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.26.3",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.3.tgz",
@@ -7600,9 +7717,7 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"optional": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/makeerror": {
 			"version": "1.0.12",
@@ -9311,6 +9426,19 @@
 				"svelte": ">=3.19.0"
 			}
 		},
+		"node_modules/svelte-jester": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/svelte-jester/-/svelte-jester-2.3.2.tgz",
+			"integrity": "sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"jest": ">= 27",
+				"svelte": ">= 3"
+			}
+		},
 		"node_modules/svelte-preprocess": {
 			"version": "4.10.7",
 			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -9587,6 +9715,49 @@
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true
+		},
+		"node_modules/ts-jest": {
+			"version": "29.0.2",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.2.tgz",
+			"integrity": "sha512-P03IUItnAjG6RkJXtjjD5pu0TryQFOwcb1YKmW63rO19V0UFqL3wiXZrmR5D7qYjI98btzIOAcYafLZ0GHAcQg==",
+			"dev": true,
+			"dependencies": {
+				"bs-logger": "0.x",
+				"fast-json-stable-stringify": "2.x",
+				"jest-util": "^29.0.0",
+				"json5": "^2.2.1",
+				"lodash.memoize": "4.x",
+				"make-error": "1.x",
+				"semver": "7.x",
+				"yargs-parser": "^21.0.1"
+			},
+			"bin": {
+				"ts-jest": "cli.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.0.0-beta.0 <8",
+				"@jest/types": "^29.0.0",
+				"babel-jest": "^29.0.0",
+				"jest": "^29.0.0",
+				"typescript": ">=4.3"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"@jest/types": {
+					"optional": true
+				},
+				"babel-jest": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
@@ -12208,6 +12379,56 @@
 				"svelte-hmr": "^0.15.0"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.18.1.tgz",
+			"integrity": "sha512-oEvsm2B/WtcHKE+IcEeeCqNU/ltFGaVyGbpcm4g/2ytuT49jrlH9x5qRKL/H3A6yfM4YAbSbC0ceT5+9CEXnLg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^5.0.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.4.4",
+				"pretty-format": "^27.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "27.5.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+					"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^17.0.1"
+					}
+				},
+				"react-is": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+					"dev": true
+				}
+			}
+		},
+		"@testing-library/svelte": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-3.2.1.tgz",
+			"integrity": "sha512-qP5nMAx78zt+a3y9Sws9BNQYP30cOQ/LXDYuAj7wNtw86b7AtB7TFAz6/Av9hFsW3IJHPBBIGff6utVNyq+F1g==",
+			"dev": true,
+			"requires": {
+				"@testing-library/dom": "^8.1.0"
+			}
+		},
 		"@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -12245,6 +12466,12 @@
 			"dev": true,
 			"optional": true,
 			"peer": true
+		},
+		"@types/aria-query": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+			"dev": true
 		},
 		"@types/babel__core": {
 			"version": "7.1.19",
@@ -12725,6 +12952,12 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"aria-query": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.2.tgz",
+			"integrity": "sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==",
+			"dev": true
+		},
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -13002,6 +13235,15 @@
 				"electron-to-chromium": "^1.4.251",
 				"node-releases": "^2.0.6",
 				"update-browserslist-db": "^1.0.9"
+			}
+		},
+		"bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"requires": {
+				"fast-json-stable-stringify": "2.x"
 			}
 		},
 		"bser": {
@@ -13649,6 +13891,12 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"dom-accessibility-api": {
+			"version": "0.5.14",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+			"dev": true
 		},
 		"domexception": {
 			"version": "4.0.0",
@@ -15670,6 +15918,12 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true
+		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -15737,6 +15991,12 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"lz-string": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"dev": true
+		},
 		"magic-string": {
 			"version": "0.26.3",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.3.tgz",
@@ -15767,9 +16027,7 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"optional": true,
-			"peer": true
+			"dev": true
 		},
 		"makeerror": {
 			"version": "1.0.12",
@@ -16987,6 +17245,13 @@
 			"dev": true,
 			"requires": {}
 		},
+		"svelte-jester": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/svelte-jester/-/svelte-jester-2.3.2.tgz",
+			"integrity": "sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==",
+			"dev": true,
+			"requires": {}
+		},
 		"svelte-preprocess": {
 			"version": "4.10.7",
 			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -17172,6 +17437,22 @@
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true
+		},
+		"ts-jest": {
+			"version": "29.0.2",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.2.tgz",
+			"integrity": "sha512-P03IUItnAjG6RkJXtjjD5pu0TryQFOwcb1YKmW63rO19V0UFqL3wiXZrmR5D7qYjI98btzIOAcYafLZ0GHAcQg==",
+			"dev": true,
+			"requires": {
+				"bs-logger": "0.x",
+				"fast-json-stable-stringify": "2.x",
+				"jest-util": "^29.0.0",
+				"json5": "^2.2.1",
+				"lodash.memoize": "4.x",
+				"make-error": "1.x",
+				"semver": "7.x",
+				"yargs-parser": "^21.0.1"
+			}
 		},
 		"ts-node": {
 			"version": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/adapter-static": "^1.0.0-next.43",
 		"@sveltejs/kit": "next",
+		"@testing-library/svelte": "^3.2.1",
 		"@types/jest": "^29.0.3",
 		"@typescript-eslint/eslint-plugin": "^5.27.0",
 		"@typescript-eslint/parser": "^5.27.0",
@@ -39,8 +40,10 @@
 		"prettier-plugin-svelte": "^2.7.0",
 		"svelte": "^3.44.0",
 		"svelte-check": "^2.7.1",
+		"svelte-jester": "^2.3.2",
 		"svelte-preprocess": "^4.10.7",
 		"tailwindcss": "^3.1.8",
+		"ts-jest": "^29.0.2",
 		"tslib": "^2.3.1",
 		"typescript": "^4.7.4",
 		"vite": "^3.1.0"

--- a/src/lib/ShotstackEditTemplate/validate.test.ts
+++ b/src/lib/ShotstackEditTemplate/validate.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals';
 import defaultJSON from '../components/Form/defaultMerge.json';
 import {
 	FIND_NOT_EMPTY,

--- a/src/lib/ShotstackEditTemplate/validate.ts
+++ b/src/lib/ShotstackEditTemplate/validate.ts
@@ -44,8 +44,7 @@ export function validateTemplate(jsonTemplate: string): IParsedEditSchema {
 		const merge = validateMerge(parsed.merge);
 		return { ...parsed, merge } as IParsedEditSchema;
 	} catch (error) {
-		if (error instanceof ValidationError) throw error;
-		else if (error.message) throw error;
+		if (error instanceof Error) throw error;
 		else throw new ValidationError('There was a problem parsing the template json');
 	}
 }

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing Shotstack module entry point Shotstack.render() should deploy the app inside target element 1`] = `
+<div>
+  <section
+    class="max-w-lg my-4 mx-auto border rounded-xl px-7 py-4 svelte-u6rap9"
+    data-cy="form-container"
+  >
+    <form
+      class="svelte-u6rap9"
+    >
+      <div
+        class="mb-6 svelte-u6rap9"
+        data-cy="template-input-section"
+      >
+        <label
+          class="text-teal-400 px-1 svelte-u6rap9"
+          for="json-input"
+        >
+          Paste template
+        </label>
+         
+        <textarea
+          class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-u6rap9"
+          data-cy="template-input"
+          id="json-input"
+        />
+      </div>
+       
+       
+       
+    </form>
+     
+    <div
+      class="svelte-u6rap9"
+      data-cy="result-section"
+    >
+      <h1
+        class="text-teal-400 px-1 inline-block mr-2 svelte-u6rap9"
+      >
+        Result
+      </h1>
+       
+      <abbr
+        class="svelte-u6rap9"
+        title="Copy to clipboard"
+      >
+        <img
+          alt="copy-button"
+          class="h-4 cursor-pointer inline mb-1 svelte-u6rap9"
+          src="img/copy-regular.svg"
+        />
+      </abbr>
+       
+      <p
+        class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-u6rap9"
+        data-cy="result"
+      >
+        {
+  "merge": []
+}
+      </p>
+    </div>
+  </section>
+</div>
+`;

--- a/src/lib/components/Form/Form.css
+++ b/src/lib/components/Form/Form.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import './Form.css';
 	import { ShotstackEditTemplateService } from '../../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './defaultMerge.json';
 

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect } from '@jest/globals';
+import Shotstack from './index';
+describe('Testing Shotstack module entry point', () => {
+	it('Shotstack.render() should deploy the app inside target element', () => {
+		const element = document.createElement('div');
+		Shotstack.render(element);
+		expect(element).toMatchSnapshot();
+	});
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import '../app.css';
 	import Form from '../lib/components/Form/Form.svelte';
 </script>
 


### PR DESCRIPTION
# Summary
- Needed a tool to test that the entry point of the module was being rendered properly.
- Adds svelte-testing-library to snapshot test the resulting render, and jester-svelte to properly process svelte files.
- Updates configuration files to follow the previously mentioned testing pipeline


# Testing evidence
jest: 
![image](https://user-images.githubusercontent.com/55909151/192910874-cd337bf4-8cc8-4950-bcd8-5710112ebca8.png)

e2e:
![image](https://user-images.githubusercontent.com/55909151/192910848-15a783a6-7667-498f-9e34-8b9a8268a941.png)
