### PR TITLE
Feat: now runs dev server before running cypress

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 npm run format
 npm run lint
 npm test
-npx cypress run
+npm run dev & npx cypress run 


### PR DESCRIPTION
# Summary
Small update to Husky pre-commit hook, so that it runs the development server before running the cypress e2e tests.

# Test evidence
e2e
![image](https://user-images.githubusercontent.com/55909151/193144271-9152f285-284f-4299-b094-555348f14e70.png)
jest
![image](https://user-images.githubusercontent.com/55909151/193144358-c8f5b1da-0370-4417-a9a3-79882901e975.png)

