### PR TITLE
Refactor: implementing a class as the default export of the library

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -5,11 +5,20 @@ export class ShotstackEditTemplateService {
 	public template: IParsedEditSchema;
 	public result: IParsedEditSchema;
 
-	constructor(template: any = { merge: [] }) {
-		this.template = template;
-		this.result = template;
+	constructor(template?: unknown) {
+		const parsedInitialTemplate = this.parseInitialTemplate(template);
+		this.template = parsedInitialTemplate;
+		this.result = parsedInitialTemplate;
 	}
-
+	parseInitialTemplate(initialTemplate: unknown) {
+		const isString = typeof initialTemplate === 'string';
+		const stringified = isString ? initialTemplate : JSON.stringify(initialTemplate);
+		try {
+			return validateTemplate(stringified);
+		} catch (error) {
+			return { merge: [] };
+		}
+	}
 	setTemplateSource(jsonTemplate: string): IParsedEditSchema {
 		try {
 			const parsedTemplate = validateTemplate(jsonTemplate);

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Testing Shotstack module entry point On initialization, should render the form inside the an element with id 'shotstack-form-field' if any 1`] = `
+<div
+  id="shotstack-form-field"
+>
+  <section
+    class="max-w-lg my-4 mx-auto border rounded-xl px-7 py-4 svelte-u6rap9"
+    data-cy="form-container"
+  >
+    <form
+      class="svelte-u6rap9"
+    >
+      <div
+        class="mb-6 svelte-u6rap9"
+        data-cy="template-input-section"
+      >
+        <label
+          class="text-teal-400 px-1 svelte-u6rap9"
+          for="json-input"
+        >
+          Paste template
+        </label>
+         
+        <textarea
+          class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-u6rap9"
+          data-cy="template-input"
+          id="json-input"
+        />
+      </div>
+       
+       
+       
+    </form>
+     
+    <div
+      class="svelte-u6rap9"
+      data-cy="result-section"
+    >
+      <h1
+        class="text-teal-400 px-1 inline-block mr-2 svelte-u6rap9"
+      >
+        Result
+      </h1>
+       
+      <abbr
+        class="svelte-u6rap9"
+        title="Copy to clipboard"
+      >
+        <img
+          alt="copy-button"
+          class="h-4 cursor-pointer inline mb-1 svelte-u6rap9"
+          src="[object Object]"
+        />
+      </abbr>
+       
+      <p
+        class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-u6rap9"
+        data-cy="result"
+      >
+        {
+  "merge": []
+}
+      </p>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`Testing Shotstack module entry point Shotstack.render() should deploy the app inside target element 1`] = `
 <div>
   <section

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -4,8 +4,7 @@
 	import { ShotstackEditTemplateService } from '../../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './defaultMerge.json';
 
-	// DEFAULT JSON VALUE PLACEHOLDER TO JSON TEXTAREA INPUT
-	const editTemplateService = new ShotstackEditTemplateService(defaultJSONInput);
+	export let editTemplateService = new ShotstackEditTemplateService(defaultJSONInput);
 
 	let template = editTemplateService.template;
 	let result = editTemplateService.result;

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -3,7 +3,8 @@ import Shotstack from './index';
 describe('Testing Shotstack module entry point', () => {
 	it('Shotstack.render() should deploy the app inside target element', () => {
 		const element = document.createElement('div');
-		Shotstack.render(element);
+		const shotstackFormService = new Shotstack();
+		shotstackFormService.render(element);
 		expect(element).toMatchSnapshot();
 	});
 });

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from '@jest/globals';
 import Shotstack from './index';
-
+import defaultJsonInput from '../lib/components/Form/defaultMerge.json';
 describe('Testing Shotstack module entry point', () => {
 	it('Shotstack.render() should deploy the app inside target element', () => {
 		const element = document.createElement('div');
@@ -9,11 +9,17 @@ describe('Testing Shotstack module entry point', () => {
 		expect(element).toMatchSnapshot();
 	});
 
-	it.only("On initialization, should render the form inside the an element with id 'shotstack-form-field' if any", () => {
+	it("On initialization, should render the form inside the an element with id 'shotstack-form-field' if any", () => {
 		const element = document.createElement('div');
 		element.id = 'shotstack-form-field';
 		document.body.append(element);
 		new Shotstack();
 		expect(element).toMatchSnapshot();
+	});
+
+	it('When passed a JSON template as a parameter, the template service should parse it correctly', () => {
+		const stringifiedJson = JSON.stringify(defaultJsonInput);
+		const shotstackService = new Shotstack(stringifiedJson);
+		expect(shotstackService.templateService.template).toEqual(defaultJsonInput);
 	});
 });

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect } from '@jest/globals';
 import Shotstack from './index';
+
 describe('Testing Shotstack module entry point', () => {
 	it('Shotstack.render() should deploy the app inside target element', () => {
 		const element = document.createElement('div');
 		const shotstackFormService = new Shotstack();
 		shotstackFormService.render(element);
+		expect(element).toMatchSnapshot();
+	});
+
+	it.only("On initialization, should render the form inside the an element with id 'shotstack-form-field' if any", () => {
+		const element = document.createElement('div');
+		element.id = 'shotstack-form-field';
+		document.body.append(element);
+		new Shotstack();
 		expect(element).toMatchSnapshot();
 	});
 });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,10 +1,26 @@
 import { Form } from './components';
+import { ShotstackEditTemplateService } from './ShotstackEditTemplate/ShotstackEditTemplateService';
 
-const Shotstack = {
-	render: (container: Element) => new Form({ target: container })
-};
-
-const element = document.querySelector('#shotstack-form-field');
-element && Shotstack.render(element);
+class Shotstack {
+	public templateService: ShotstackEditTemplateService;
+	constructor(
+		initialTemplate?: unknown,
+		public container = document.querySelector('#shotstack-form-field')
+	) {
+		this.templateService = new ShotstackEditTemplateService(initialTemplate);
+		this.initialize();
+	}
+	initialize() {
+		this.container && this.render(this.container);
+	}
+	render(container: Element) {
+		new Form({
+			target: container,
+			props: {
+				editTemplateService: this.templateService
+			}
+		});
+	}
+}
 
 export default Shotstack;


### PR DESCRIPTION
# Summary
- According to required specifications, library's default export should be initialized with the 'new' keyword, with up to two optional parameters, a json template and the container where the form will be rendered.
- Now validates initial template
- Adding snapshot test for merge rendering on initialization when an element with id shotstack-form-field
- Updated snapshot test

# Evidence
e2e
![image](https://user-images.githubusercontent.com/55909151/193552570-6fafc891-e173-4d0c-84a3-32c2fed7f860.png)

jest
![image](https://user-images.githubusercontent.com/55909151/193552618-0eeb4547-4763-41f5-89dc-63a1c2adb4e4.png)
