### PR TITLE
Feat: Adding events, handlers and related methods to Shotstack class

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+	const content: any;
+	export default content;
+}

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -13,3 +13,16 @@ export interface IParsedEditSchema {
 	merge: MergeField[];
 	[key: string]: any;
 }
+
+export type TemplateEvent = 'submit' | 'change';
+export type ResultTemplateCallback = (resultTemplate: IParsedEditSchema) => void;
+
+export interface IShotstackEvents {
+	change: ResultTemplateCallback;
+	submit: ResultTemplateCallback;
+}
+
+export interface IShotstackHandlers {
+	change: ResultTemplateCallback[];
+	submit: ResultTemplateCallback[];
+}

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect } from '@jest/globals';
 import Shotstack from './index';
 import defaultJsonInput from '../lib/components/Form/defaultMerge.json';
+import type { IParsedEditSchema } from './ShotstackEditTemplate/types';
 describe('Testing Shotstack module entry point', () => {
 	it('Shotstack.render() should deploy the app inside target element', () => {
 		const element = document.createElement('div');
@@ -21,5 +22,31 @@ describe('Testing Shotstack module entry point', () => {
 		const stringifiedJson = JSON.stringify(defaultJsonInput);
 		const shotstackService = new Shotstack(stringifiedJson);
 		expect(shotstackService.templateService.template).toEqual(defaultJsonInput);
+	});
+
+	it("When .on(event, fn) is called, it should add a 'fn' handler for that particular 'event'", () => {
+		const shotstackService = new Shotstack();
+		const mockChange = jest.fn();
+		const find = 'Hello';
+		const replace = 'World';
+		const newReplace = 'New World';
+		const mergeEntry = { find, replace };
+		const replacedEntry = { find, replace: newReplace };
+		const jsonTemplate: IParsedEditSchema = { merge: [mergeEntry] };
+		const expectedResultTemplate: IParsedEditSchema = { merge: [replacedEntry] };
+
+		shotstackService.on('change', mockChange);
+		shotstackService.templateService.setTemplateSource(JSON.stringify(jsonTemplate));
+		expect(mockChange).toHaveBeenCalledWith(jsonTemplate);
+
+		shotstackService.templateService.updateResultMergeFields(replacedEntry);
+		expect(mockChange).toHaveBeenCalledWith(expectedResultTemplate);
+		expect(mockChange).toHaveBeenCalledTimes(2);
+
+		const mockSubmit = jest.fn();
+		shotstackService.on('submit', mockSubmit);
+		shotstackService.submit();
+		expect(mockSubmit).toHaveBeenCalled();
+		expect(mockSubmit).toHaveBeenCalledWith(expectedResultTemplate);
 	});
 });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 import { Form } from './components';
 import { ShotstackEditTemplateService } from './ShotstackEditTemplate/ShotstackEditTemplateService';
+import type { IShotstackEvents, TemplateEvent } from './ShotstackEditTemplate/types';
 
 class Shotstack {
 	public templateService: ShotstackEditTemplateService;
@@ -10,6 +11,15 @@ class Shotstack {
 		this.templateService = new ShotstackEditTemplateService(initialTemplate);
 		this.initialize();
 	}
+
+	on(eventName: TemplateEvent, callback: IShotstackEvents[TemplateEvent]) {
+		this.templateService.on(eventName, callback);
+	}
+
+	submit() {
+		this.templateService.submit();
+	}
+
 	initialize() {
 		this.container && this.render(this.container);
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,24 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"types": ["cypress", "svelte"]
-	}
+		"types": ["cypress", "svelte", "jest"]
+	},
+	"include": [
+		"ambient.d.ts",
+		"../vite.config.ts",
+		"../src/**/*.js",
+		"../src/**/*.ts",
+		"../src/**/*.svelte",
+		"../src/**/*.js",
+		"../src/**/*.ts",
+		"../src/**/*.svelte",
+		"../tests/**/*.js",
+		"../tests/**/*.ts",
+		"../tests/**/*.svelte",
+		"**/*.test.ts",
+		"custom.d.ts"
+	],
+	"exclude": ["../node_modules/**", "./[!ambient.d.ts]**"]
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes


### PR DESCRIPTION
# Summary
- Complies with the required Shotstack.on('event', callback) class method, accord to specifications.
- Adds tests for Shotstack.on
- In order to mock jest functions, additional configurations were required for tsconfig.json, including a module for SVG files.

# Test evidence
Cypress e2e:
![image](https://user-images.githubusercontent.com/55909151/193705623-39552b46-0494-4f9d-a514-3dc21bbcea6e.png)

Jest: 
![image](https://user-images.githubusercontent.com/55909151/193705659-88c536d0-2f3d-404b-85c6-a06a2532e0cb.png)
