### PR TITLE
Refactor: replaced result with getter+setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ To use provided styles: include a `<link rel="stylesheet" href="style.css">` tag
 
 ### Shotstack references
 
-|        | method | arguments           | effect                                                 |
-| ------ | ------ | ------------------- | ------------------------------------------------------ |
-| public | render | target: HTMLElement | Renders and appends the form inside target DOM element |
+|        | method      | arguments                                                        | effect                                                                                                                                                                                                                                                                                                                                           |
+| ------ | ----------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|        | constructor | initialTemplate?: any, container?: HTMLElement                   | Mounts the component with the provided template inside the container. If no initial template, Shotstack will mount with minimal data. If no container is found, it will look for an HTML element with an id of "shotstack-form-field". If this also fails, it will not render anything, and the render method will need to be called afterwards. |
+| public | render      | target: HTMLElement                                              | Renders and appends the form inside target DOM element                                                                                                                                                                                                                                                                                           |
+| public | on          | event: 'change' \| 'submit', callback: (resultTemplate) => void; | Appends a new event handler for a specific event at the component's lifecycle                                                                                                                                                                                                                                                                    |
+| public | submit      |                                                                  | Calls all submit event handlers (default is none)                                                                                                                                                                                                                                                                                                |
 
 ### Using Shotstack as a module import
 
@@ -103,10 +106,10 @@ To implement this library as a global variable, just include the following in th
 
 <body>
     <h1>My business</h1>
-    <div id="root"></div>
+    <div id="shotstack-form-field"></div>
     <div>
         <script>
-            let form = Shotstack.render(document.querySelector("#root"))
+            let shotstack = new Shotstack()
         </script>
     </div>
 </body>

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -21,6 +21,29 @@ describe('ShotstackEditTemplateService', () => {
 	});
 });
 
+describe('ShotstackEditTempalteService._results', () => {
+	const sampleJson = { merge: [{ find: 'Hello', replace: 'World' }] };
+	const modifiedJson = { merge: [{ find: 'Hello', replace: 'Worlds' }] };
+
+	test('Getter should return current result template value', () => {
+		const editTemplateService = new ShotstackEditTemplateService(sampleJson);
+		expect(editTemplateService.result).toEqual(sampleJson);
+	});
+	test('Setter should establish new updated value', () => {
+		const editTemplateService = new ShotstackEditTemplateService(sampleJson);
+		editTemplateService.result = modifiedJson;
+		expect(editTemplateService.result).toEqual(modifiedJson);
+	});
+	test('Setter should call onChange event handlers with result as argument', () => {
+		const editTemplateService = new ShotstackEditTemplateService(sampleJson);
+		const mock = jest.fn();
+		editTemplateService.on('change', mock);
+		editTemplateService.result = modifiedJson;
+		expect(mock).toHaveBeenCalled();
+		expect(mock).toHaveBeenCalledWith(modifiedJson);
+	});
+});
+
 describe('ShotstackEditTemplateService.setTemplateSource', () => {
 	test('Correctly updates the source edit object', () => {
 		const editTemplateService = new ShotstackEditTemplateService();

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -9,13 +9,20 @@ import { validateTemplate } from './validate';
 
 export class ShotstackEditTemplateService {
 	public template: IParsedEditSchema;
-	public result: IParsedEditSchema;
+	private _result: IParsedEditSchema;
 	private handlers: IShotstackHandlers;
 	constructor(template?: unknown) {
 		const parsedInitialTemplate = this.parseInitialTemplate(template);
 		this.template = parsedInitialTemplate;
-		this.result = parsedInitialTemplate;
+		this._result = parsedInitialTemplate;
 		this.handlers = { change: [], submit: [] };
+	}
+	public set result(validParsedTemplate: IParsedEditSchema) {
+		this._result = validParsedTemplate;
+		this.handlers.change.forEach((fn) => fn(validParsedTemplate));
+	}
+	public get result() {
+		return this._result;
 	}
 
 	on(eventName: TemplateEvent, callback: IShotstackEvents[TemplateEvent]) {
@@ -26,15 +33,12 @@ export class ShotstackEditTemplateService {
 		this.handlers.submit.forEach((fn) => fn(this.result));
 	}
 
-	change() {
-		this.handlers.change.forEach((fn) => fn(this.result));
-	}
-
 	parseInitialTemplate(initialTemplate: unknown) {
 		const isString = typeof initialTemplate === 'string';
 		const stringified = isString ? initialTemplate : JSON.stringify(initialTemplate);
 		try {
-			return validateTemplate(stringified);
+			const validTemplate = validateTemplate(stringified);
+			return validTemplate;
 		} catch (error) {
 			return { merge: [] };
 		}
@@ -44,7 +48,6 @@ export class ShotstackEditTemplateService {
 			const parsedTemplate = validateTemplate(jsonTemplate);
 			this.template = parsedTemplate;
 			this.result = parsedTemplate;
-			this.change();
 			return parsedTemplate;
 		} catch (err) {
 			if (err instanceof Error) throw err;
@@ -59,7 +62,6 @@ export class ShotstackEditTemplateService {
 			mergeField?.find === mergeFieldInput.find ? validMergeField : mergeField
 		);
 		this.result = { ...this.result, merge };
-		this.change();
 		return merge;
 	}
 }

--- a/src/lib/public/README.md
+++ b/src/lib/public/README.md
@@ -12,6 +12,7 @@ After downloading the released `package` from this repository you’ll be provid
 │   Shotstack.js
 │   Shotstack.iife.js
 │   style.css
+
 ```
 
 To use, you can either import the library as an es module or include Shotstack as a global variable.
@@ -20,9 +21,12 @@ To use provided styles: include a `<link rel="stylesheet" href="style.css">` tag
 
 ### Shotstack references
 
-|        | method | arguments           | effect                                                 |
-| ------ | ------ | ------------------- | ------------------------------------------------------ |
-| public | render | target: HTMLElement | Renders and appends the form inside target DOM element |
+|        | method      | arguments                                                        | effect                                                                                                                                                                                                                                                                                                                                           |
+| ------ | ----------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|        | constructor | initialTemplate?: any, container?: HTMLElement                   | Mounts the component with the provided template inside the container. If no initial template, Shotstack will mount with minimal data. If no container is found, it will look for an HTML element with an id of "shotstack-form-field". If this also fails, it will not render anything, and the render method will need to be called afterwards. |
+| public | render      | target: HTMLElement                                              | Renders and appends the form inside target DOM element                                                                                                                                                                                                                                                                                           |
+| public | on          | event: 'change' \| 'submit', callback: (resultTemplate) => void; | Appends a new event handler for a specific event at the component's lifecycle                                                                                                                                                                                                                                                                    |
+| public | submit      |                                                                  | Calls all submit event handlers (default is none)                                                                                                                                                                                                                                                                                                |
 
 ### Using Shotstack as a module import
 
@@ -84,10 +88,10 @@ To implement this library as a global variable, just include the following in th
 
 <body>
     <h1>My business</h1>
-    <div id="root"></div>
+    <div id="shotstack-form-field"></div>
     <div>
         <script>
-            let form = Shotstack.render(document.querySelector("#root"))
+            let shotstack = new Shotstack()
         </script>
     </div>
 </body>


### PR DESCRIPTION
# Summary
- Replaces result property with setter and getter to have a better control on the onChange lifecycle, by triggering every change handler when setting the new property and ensuring they work with a valid json template.
- Adds tests for this new functionality

#Test evidence
e2e:
![image](https://user-images.githubusercontent.com/55909151/193738748-f05a6a1b-d673-438f-89a0-99005e80dd3f.png)

jest:
![image](https://user-images.githubusercontent.com/55909151/193738792-8e5ed858-ce18-4ae6-be68-527b908d634d.png)
