### PR TITLE
Refactor: form error handling and display

### DIFF
--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -30,7 +30,6 @@ exports[`Testing Shotstack module entry point On initialization, should render t
       </div>
        
        
-       
     </form>
      
     <div
@@ -93,7 +92,6 @@ exports[`Testing Shotstack module entry point Shotstack.render() should deploy t
           id="json-input"
         />
       </div>
-       
        
        
     </form>

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -36,16 +36,6 @@
 		navigator.clipboard.writeText(JSON.stringify(result));
 		alert('JSON copied to clipboard!');
 	}
-
-	function safeApply(val: any) {
-		if (typeof val === 'string') return val;
-		else
-			try {
-				return JSON.stringify(val);
-			} catch (error) {
-				return val;
-			}
-	}
 </script>
 
 <section data-cy="form-container" class="max-w-lg my-4 mx-auto border rounded-xl px-7 py-4">
@@ -82,7 +72,7 @@
 								class="border w-full mb-3 pl-2 py-1 text-stone-500"
 								id={find}
 								type="text"
-								value={safeApply(replace)}
+								value={replace}
 								on:input={(e) => handleFormInput({ find, replace: e.currentTarget.value })}
 							/>
 						</div>

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -8,17 +8,16 @@
 
 	let template = editTemplateService.template;
 	let result = editTemplateService.result;
-	let templateError: string;
-	let resultError: string;
+	let error: string | null = null;
 
 	function handleTemplateInput(e: any) {
 		try {
 			const updatedTemplate = editTemplateService.setTemplateSource(e.target.value);
 			template = updatedTemplate;
 			result = updatedTemplate;
-			templateError = '';
+			error = null;
 		} catch (err: any) {
-			templateError = err.message;
+			error = err.message;
 		}
 	}
 
@@ -26,9 +25,9 @@
 		try {
 			const updatedMergeFields = editTemplateService.updateResultMergeFields(mergeField);
 			result = { ...result, merge: updatedMergeFields };
-			resultError = '';
+			error = null;
 		} catch (err: any) {
-			resultError = err.message;
+			error = err.message;
 		}
 	}
 
@@ -51,15 +50,15 @@
 			/>
 		</div>
 
-		{#if templateError}
+		{#if error}
 			<p data-cy="template-input-error" class=" bg-rose-200 rounded py-2 px-4">
 				<span class="monospace text-orange-900">
-					{templateError}
+					{error}
 				</span>
 			</p>
 		{/if}
 
-		{#if template.merge?.length && !templateError}
+		{#if template.merge?.length && !error}
 			<div data-cy="merge-fields-input-section">
 				<h1 class="text-teal-400 px-1">Modify Merge Values</h1>
 				<div class="border p-4 mb-6">
@@ -80,17 +79,9 @@
 				</div>
 			</div>
 		{/if}
-
-		{#if resultError}
-			<p data-cy="merge-fields-input-error" class=" bg-rose-200 rounded py-2 px-4">
-				<span class="monospace text-orange-900">
-					{resultError}
-				</span>
-			</p>
-		{/if}
 	</form>
 
-	{#if !resultError && !templateError}
+	{#if !error}
 		<div data-cy="result-section">
 			<h1 class="text-teal-400 px-1 inline-block mr-2">Result</h1>
 			<abbr title="Copy to clipboard">


### PR DESCRIPTION
# Context
- Since #18, form input fields are typecasted into strings, and will no longer throw any kind of errors. As such, there's no need to safe apply input values, and in any error, they will be typecasted into strings anyway.

# Summary
- Removed safeapply function
- Removed merge fields input error (misnamed as resultError)
- Renamed template error as Error to show only one error field
- Updated snapshots

# Testing evidence
e2e: 
![image](https://user-images.githubusercontent.com/55909151/193922624-1c68b80c-998f-4386-bb48-69f2a23a2419.png)

jest:
![image](https://user-images.githubusercontent.com/55909151/193922704-f48457dd-cc46-4e99-9de9-67798ea19944.png)
