### PR TITLE
Feat: removed all business logic from form component. Reworked error handling.

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -3,8 +3,6 @@
  */
 
 import { describe, expect, test } from '@jest/globals';
-import { INVALID_JSON, MERGE_NOT_FOUND } from './constants';
-
 import { ShotstackEditTemplateService } from './ShotstackEditTemplateService';
 
 describe('ShotstackEditTemplateService', () => {
@@ -55,10 +53,10 @@ describe('ShotstackEditTemplateService.setTemplateSource', () => {
 		expect(editTemplateService.template.merge).toEqual([{ find: 'test', replace: 'foo' }]);
 	});
 
-	test('Throws error if not merge array passed', () => {
+	test('When providing an incorrect json, should update error property with error', () => {
 		const editTemplateService = new ShotstackEditTemplateService();
-		expect(() => editTemplateService.setTemplateSource('<>')).toThrowError(INVALID_JSON);
-		expect(() => editTemplateService.setTemplateSource('{}')).toThrowError(MERGE_NOT_FOUND);
+		editTemplateService.setTemplateSource('<>');
+		expect(editTemplateService.error).not.toEqual(null);
 	});
 });
 

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -38,7 +38,8 @@ export class ShotstackEditTemplateService {
 	}
 
 	submit() {
-		this.handlers.submit.forEach((fn) => fn(this.result));
+		if (this.error) throw this.error;
+		else this.handlers.submit.forEach((fn) => fn(this.result));
 	}
 
 	setTemplateSource(jsonTemplate: unknown) {

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -1,5 +1,5 @@
 import type { IParsedEditSchema, IShotstackEvents, IShotstackHandlers, MergeField } from './types';
-import { validateTemplate } from './validate';
+import { validateError, validateTemplate, stringifyIfNotString } from './validate';
 
 export class ShotstackEditTemplateService {
 	public template: IParsedEditSchema;
@@ -8,12 +8,13 @@ export class ShotstackEditTemplateService {
 	private handlers: IShotstackHandlers;
 
 	constructor(template?: unknown) {
-		const parsedInitialTemplate = this.parseInitialTemplate(template);
-		this.template = parsedInitialTemplate;
 		this._error = null;
-		this._result = parsedInitialTemplate;
+		this.template = { merge: [] };
+		this._result = { merge: [] };
 		this.handlers = { change: [], submit: [], error: [] };
+		this.setTemplateSource(template);
 	}
+
 	public set error(err: null | Error) {
 		const previousError = this._error;
 		this._error = err;
@@ -40,25 +41,15 @@ export class ShotstackEditTemplateService {
 		this.handlers.submit.forEach((fn) => fn(this.result));
 	}
 
-	parseInitialTemplate(initialTemplate: unknown) {
-		const isString = typeof initialTemplate === 'string';
-		const stringified = isString ? initialTemplate : JSON.stringify(initialTemplate);
+	setTemplateSource(jsonTemplate: unknown) {
 		try {
-			const validTemplate = validateTemplate(stringified);
-			return validTemplate;
-		} catch (error) {
-			return { merge: [] };
-		}
-	}
-	setTemplateSource(jsonTemplate: string): IParsedEditSchema {
-		try {
-			const parsedTemplate = validateTemplate(jsonTemplate);
+			const parsedTemplate = validateTemplate(stringifyIfNotString(jsonTemplate));
 			this.template = parsedTemplate;
 			this.result = parsedTemplate;
-			return parsedTemplate;
+			this.error = null;
 		} catch (err) {
-			if (err instanceof Error) throw err;
-			throw new Error('Error parsing JSON');
+			const validError = validateError(err);
+			this.error = validError;
 		}
 	}
 

--- a/src/lib/ShotstackEditTemplate/constants.ts
+++ b/src/lib/ShotstackEditTemplate/constants.ts
@@ -6,3 +6,4 @@ export const FIND_NOT_FOUND = `A 'find' property is required on every element in
 export const FIND_NOT_STRING = `Every 'find' property inside 'merge' must be of type string`;
 export const FIND_NOT_EMPTY = `Every 'find' property inside 'merge' must be a string of length equal to or higher than one`;
 export const REPLACE_NOT_FOUND = `A 'replace' property is required on every element inside 'merge'`;
+export const UNEXPECTED_ERROR = 'Unexpected error while parsing template JSON';

--- a/src/lib/ShotstackEditTemplate/validate.ts
+++ b/src/lib/ShotstackEditTemplate/validate.ts
@@ -45,7 +45,7 @@ export function validateTemplate(jsonTemplate: string): IParsedEditSchema {
 		const merge = validateMerge(parsed.merge);
 		return { ...parsed, merge } as IParsedEditSchema;
 	} catch (error) {
-		throw validateError(error)
+		throw validateError(error);
 	}
 }
 
@@ -59,16 +59,21 @@ export function validateMerge(template: unknown[]) {
 	});
 	return validTemplate.map(({ find, replace }) => ({
 		find,
-		replace: typeof replace === 'string' ? replace : JSON.stringify(replace)
+		replace: stringifyIfNotString(replace)
 	}));
 }
 
 function hasErrorMessage(error: unknown): error is { message: string } {
-	return typeof error === 'object' && error !== null && 'message' in error
+	return typeof error === 'object' && error !== null && 'message' in error;
 }
 
 export function validateError(error: unknown): Error {
-	if (error instanceof Error) return error
-	else if (hasErrorMessage(error)) return new ValidationError(error.message)
-	else return new ValidationError(UNEXPECTED_ERROR)
+	if (error instanceof Error) return error;
+	else if (hasErrorMessage(error)) return new ValidationError(error.message);
+	else return new ValidationError(UNEXPECTED_ERROR);
+}
+
+export function stringifyIfNotString(input: unknown): string {
+	if (typeof input === 'string') return input;
+	else return JSON.stringify(input);
 }

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -3,37 +3,33 @@
 	import copyRegular from './copy-regular.svg';
 	import { ShotstackEditTemplateService } from '../../ShotstackEditTemplate/ShotstackEditTemplateService';
 	import defaultJSONInput from './defaultMerge.json';
+	import type { IParsedEditSchema } from '$lib/ShotstackEditTemplate/types';
 
 	export let editTemplateService = new ShotstackEditTemplateService(defaultJSONInput);
 
 	let template = editTemplateService.template;
 	let result = editTemplateService.result;
-	let error: string | null = null;
+	let error: Error | null = null;
 
-	function handleTemplateInput(e: any) {
-		try {
-			const updatedTemplate = editTemplateService.setTemplateSource(e.target.value);
-			template = updatedTemplate;
-			result = updatedTemplate;
-			error = null;
-		} catch (err: any) {
-			error = err.message;
-		}
+	function handleTemplateInput(value: string) {
+		editTemplateService.setTemplateSource(value);
+		template = editTemplateService.template;
+		result = editTemplateService.result;
+		error = editTemplateService.error;
 	}
 
 	function handleFormInput(mergeField: { find: string; replace: string }) {
-		try {
-			const updatedMergeFields = editTemplateService.updateResultMergeFields(mergeField);
-			result = { ...result, merge: updatedMergeFields };
-			error = null;
-		} catch (err: any) {
-			error = err.message;
-		}
+		editTemplateService.updateResultMergeFields(mergeField);
+		result = editTemplateService.result;
 	}
 
 	function handleCopyToClipboardClick() {
 		navigator.clipboard.writeText(JSON.stringify(result));
 		alert('JSON copied to clipboard!');
+	}
+
+	function formatJson(json: IParsedEditSchema) {
+		return JSON.stringify(json, null, 2);
 	}
 </script>
 
@@ -45,15 +41,15 @@
 				data-cy="template-input"
 				class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none"
 				id="json-input"
-				on:input={handleTemplateInput}
-				value={JSON.stringify(template, null, 2)}
+				on:input={(e) => handleTemplateInput(e.currentTarget.value)}
+				value={formatJson(template)}
 			/>
 		</div>
 
 		{#if error}
 			<p data-cy="template-input-error" class=" bg-rose-200 rounded py-2 px-4">
 				<span class="monospace text-orange-900">
-					{error}
+					{error.message}
 				</span>
 			</p>
 		{/if}
@@ -93,7 +89,7 @@
 				/>
 			</abbr>
 			<p data-cy="result" class="h-60 overflow-auto  border p-4 whitespace-pre monospace">
-				{JSON.stringify(result, null, 2)}
+				{formatJson(result)}
 			</p>
 		</div>
 	{/if}


### PR DESCRIPTION
# Context
Expected behaviour:
- When calling Shotstack as a constructor, e.g ```new Shotstack(template)```,  if the initial template had any kind of error, the form should reflect that by rendering an error field and message.

Actual behaviour before this PR:
- When Shotstack was called as a constructor, the form would render normally with default data, with no error message whatsoever.

# Summary
- Related PR's
#32 
#34 
#37 

- Updating form component's by making its only responsability to organize and render data incoming from EditTemplate component.
- Updating EditTemplate component by incorporating responsabilities previously held by form component, particularly error handling and validating on mount
- Submit method will throw an error and will not run submit handlers if service current error property is not null.

# TBD
- Add more tests for additional branch statement coverage

# Test evidence
jest
![image](https://user-images.githubusercontent.com/55909151/194012078-afe2aab5-725f-486b-bcb2-3fbd95816f83.png)

e2e
![image](https://user-images.githubusercontent.com/55909151/194012031-2a2db6ed-308c-4a28-b3a6-112506885c19.png)
