### PR TITLE
Feat: events derived from component state are provided with current state and previous state

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.test.ts
@@ -19,7 +19,28 @@ describe('ShotstackEditTemplateService', () => {
 	});
 });
 
-describe('ShotstackEditTempalteService._results', () => {
+describe('ShoststackEditTemplateService._error', () => {
+	test('If passed a valid template, error should be null', () => {
+		const shotstack = new ShotstackEditTemplateService({
+			merge: [{ find: 'NAME', replace: 'John' }]
+		});
+		expect(shotstack.error).toEqual(null);
+	});
+	test('If passed an invalid template. error should be equal to Error object', () => {
+		const shotstack = new ShotstackEditTemplateService();
+		expect(shotstack.error).toBeInstanceOf(Error);
+	});
+	test('on Error, should trigger all error events', () => {
+		const shotstack = new ShotstackEditTemplateService({
+			merge: [{ find: 'NAME', replace: 'John' }]
+		});
+		const mock = jest.fn();
+		shotstack.on('error', mock);
+		shotstack.setTemplateSource('<>');
+		expect(mock).toHaveBeenCalled();
+	});
+});
+describe('ShoststackEditTemplateService._results', () => {
 	const sampleJson = { merge: [{ find: 'Hello', replace: 'World' }] };
 	const modifiedJson = { merge: [{ find: 'Hello', replace: 'Worlds' }] };
 
@@ -38,7 +59,25 @@ describe('ShotstackEditTempalteService._results', () => {
 		editTemplateService.on('change', mock);
 		editTemplateService.result = modifiedJson;
 		expect(mock).toHaveBeenCalled();
-		expect(mock).toHaveBeenCalledWith(modifiedJson);
+		expect(mock).toHaveBeenCalledWith(modifiedJson, sampleJson);
+	});
+});
+
+describe('ShotstackEditTemplateService.submit', () => {
+	const sampleJson = { merge: [{ find: 'Hello', replace: 'World' }] };
+	test('If state is in error, should not call any submit event handlers', () => {
+		const editTemplateService = new ShotstackEditTemplateService('Invalid json');
+		const mock = jest.fn();
+		editTemplateService.on('submit', mock);
+		expect(editTemplateService.submit).toThrow();
+		expect(mock).not.toHaveBeenCalled();
+	});
+	test('When called, should call all submit event handlers', () => {
+		const editTemplateService = new ShotstackEditTemplateService(sampleJson);
+		const mock = jest.fn();
+		editTemplateService.on('submit', mock);
+		editTemplateService.submit();
+		expect(mock).toHaveBeenCalledWith(sampleJson);
 	});
 });
 

--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -16,7 +16,7 @@ export class ShotstackEditTemplateService {
 	}
 
 	public set error(err: null | Error) {
-		const previousError = this._error;
+		const previousError = (this._error && { ...this._error }) || null;
 		this._error = err;
 		if (err !== null) this.handlers.error.forEach((fn) => fn(err, previousError));
 	}
@@ -26,9 +26,11 @@ export class ShotstackEditTemplateService {
 	}
 
 	public set result(validParsedTemplate: IParsedEditSchema) {
+		const previousResult = { ...this._result };
 		this._result = validParsedTemplate;
-		this.handlers.change.forEach((fn) => fn(validParsedTemplate));
+		this.handlers.change.forEach((fn) => fn(validParsedTemplate, previousResult));
 	}
+
 	public get result() {
 		return this._result;
 	}

--- a/src/lib/ShotstackEditTemplate/types.ts
+++ b/src/lib/ShotstackEditTemplate/types.ts
@@ -11,16 +11,20 @@ export interface MergeField {
 
 export interface IParsedEditSchema {
 	merge: MergeField[];
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export type TemplateEvent = 'submit' | 'change' | 'error';
-export type ResultTemplateCallback = (resultTemplate: IParsedEditSchema) => void;
+export type ResultTemplateCallback = (
+	resultTemplate: IParsedEditSchema,
+	previousResult?: IParsedEditSchema
+) => void;
 export type ErrorCallback = (err: unknown, previousError?: unknown) => void;
+export type SubmitCallback = (resultTemplate: IParsedEditSchema) => void;
 
 export interface IShotstackEvents {
 	change: ResultTemplateCallback;
-	submit: ResultTemplateCallback;
+	submit: SubmitCallback;
 	error: ErrorCallback;
 }
 

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -26,6 +26,7 @@ describe('Testing Shotstack module entry point', () => {
 
 	it("When .on(event, fn) is called, it should add a 'fn' handler for that particular 'event'", () => {
 		const shotstackService = new Shotstack();
+		const defaultMergeField = shotstackService.templateService.result;
 		const mockChange = jest.fn();
 		const find = 'Hello';
 		const replace = 'World';
@@ -37,10 +38,10 @@ describe('Testing Shotstack module entry point', () => {
 
 		shotstackService.on('change', mockChange);
 		shotstackService.templateService.setTemplateSource(JSON.stringify(jsonTemplate));
-		expect(mockChange).toHaveBeenCalledWith(jsonTemplate);
+		expect(mockChange).toHaveBeenCalledWith(jsonTemplate, defaultMergeField);
 
 		shotstackService.templateService.updateResultMergeFields(replacedEntry);
-		expect(mockChange).toHaveBeenCalledWith(expectedResultTemplate);
+		expect(mockChange).toHaveBeenCalledWith(expectedResultTemplate, jsonTemplate);
 		expect(mockChange).toHaveBeenCalledTimes(2);
 
 		const mockSubmit = jest.fn();


### PR DESCRIPTION
# Summary
- 'change' and 'error' events now provide two parameters to every callback function in the handler array, the first argument being the new set state and the second parameter is the previous state.
- Adds unit tests for all three events

# Test evidence
jest
![image](https://user-images.githubusercontent.com/55909151/194234630-bb545fa5-36bf-4d81-a9c3-8676fe8e2057.png)
e2e
![image](https://user-images.githubusercontent.com/55909151/194234897-660f6087-b26d-41e1-99d7-436242ea9373.png)
