### PR TITLE
Feat: adding tests for validation helper functions and cleared lint warnings

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,4 +1,4 @@
 declare module '*.svg' {
-	const content: any;
+	const content: string;
 	export default content;
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-	e2e: {
-		setupNodeEvents(on, config) {
-			// implement node event listeners here
-		}
-	},
+	// e2e: {
+	// 	setupNodeEvents(on, config) {
+	// 		implement node event listeners here
+	// 	}
+	// },
+	e2e: {},
 	video: false
 });

--- a/cypress/e2e/exists.cy.ts
+++ b/cypress/e2e/exists.cy.ts
@@ -185,7 +185,7 @@ describe('Result JSON', () => {
 	});
 	it('Replace values are cast into valid JSON types, or if invalid, into strings', () => {
 		// Arrange
-		const jsonValidTypes: { [key: string]: any } = {
+		const jsonValidTypes: { [key: string]: unknown } = {
 			bNull: null,
 			bFalse: false,
 			bTrue: true,
@@ -194,7 +194,7 @@ describe('Result JSON', () => {
 			objects: { a: 'a', b: 'b' },
 			array: [1, '2', 3]
 		};
-		const jsonInvalidTypes: { [key: string]: any } = {
+		const jsonInvalidTypes: { [key: string]: unknown } = {
 			fn: '() => { }',
 			bUndefined: 'undefined',
 			symbol: "Symbol('foo')",

--- a/src/lib/ShotstackEditTemplate/constants.ts
+++ b/src/lib/ShotstackEditTemplate/constants.ts
@@ -7,3 +7,4 @@ export const FIND_NOT_STRING = `Every 'find' property inside 'merge' must be of 
 export const FIND_NOT_EMPTY = `Every 'find' property inside 'merge' must be a string of length equal to or higher than one`;
 export const REPLACE_NOT_FOUND = `A 'replace' property is required on every element inside 'merge'`;
 export const UNEXPECTED_ERROR = 'Unexpected error while parsing template JSON';
+export const MERGE_INDEX_NOT_OBJECT = "Every element inside the 'merge' should be an object";

--- a/src/lib/ShotstackEditTemplate/validate.test.ts
+++ b/src/lib/ShotstackEditTemplate/validate.test.ts
@@ -5,12 +5,21 @@ import {
 	FIND_NOT_FOUND,
 	FIND_NOT_STRING,
 	INVALID_JSON,
+	MERGE_INDEX_NOT_OBJECT,
 	MERGE_NOT_ARRAY,
 	MERGE_NOT_EMPTY,
 	MERGE_NOT_FOUND,
-	REPLACE_NOT_FOUND
+	REPLACE_NOT_FOUND,
+	UNEXPECTED_ERROR
 } from './constants';
-import { validateTemplate, ValidationError, validateMerge } from './validate';
+import {
+	validateTemplate,
+	validateMerge,
+	stringifyIfNotString,
+	validateError,
+	ValidationError,
+	hasErrorMessage
+} from './validate';
 describe('ShotstackEditTemplate/validate.ts', () => {
 	test('If valid stringified json is passed, it should return a valid json', () => {
 		const validStringified = JSON.stringify(defaultJSON);
@@ -39,6 +48,10 @@ describe('ShotstackEditTemplate/validate.ts', () => {
 });
 
 describe('ShotstackEditTemplate/validate.ts .validateMerge', () => {
+	test('Should throw if a merge item is not an object', () => {
+		const objectNotFound = ['Items'];
+		expect(() => validateMerge(objectNotFound)).toThrowError(MERGE_INDEX_NOT_OBJECT);
+	});
 	test("Should throw if a merge item doesn't have the find prop", () => {
 		const mergeNotFound = [{ foo: 'bar', replace: 'bar' }];
 		expect(() => validateMerge(mergeNotFound)).toThrowError(FIND_NOT_FOUND);
@@ -65,5 +78,49 @@ describe('ShotstackEditTemplate/validate.ts .validateMerge', () => {
 		const isAlwaysString = [{ find: 'bar', replace: 'foo' }];
 		const result = validateMerge(isAlwaysString);
 		expect(result).toStrictEqual([{ find: 'bar', replace: 'foo' }]);
+	});
+});
+
+describe('validate.ts/stringifyIfNotString', () => {
+	test('Should stringify any value', () => {
+		const string = stringifyIfNotString(null);
+		expect(string).toEqual('null');
+	});
+	test('If input is already string, should not stringify further', () => {
+		const sample = 'hello';
+		const stringifiedSample = JSON.stringify(sample);
+		const string = stringifyIfNotString(sample);
+		expect(string).toEqual(sample);
+		expect(string).not.toEqual(stringifiedSample);
+	});
+});
+
+describe('validate.ts/validateError', () => {
+	test('When passing an error that extends Error, should return the same element', () => {
+		const error = new Error('This is an error');
+		const validError = validateError(error);
+		expect(validError).toEqual(error);
+	});
+	test('When passing any other kind of error, should return an ValidationError element', () => {
+		const error = 'ERROR';
+		const validError = validateError(error);
+		expect(validError).not.toEqual(error);
+		expect(validError).toEqual(new ValidationError(UNEXPECTED_ERROR));
+	});
+	test('When passing an error like object with a message, should return a ValidationError with that message', () => {
+		const errorLike = { message: 'Error' };
+		const validError = validateError(errorLike);
+		expect(validError).toEqual(new ValidationError(errorLike.message));
+	});
+});
+
+describe('validate.ts/hasErrorMessage', () => {
+	test('When passed an error-like object with a message, should return true', () => {
+		const error = new Error('Message');
+		const notError = 'Message';
+		const isErrorLike = hasErrorMessage(error);
+		const isNotErrorLike = hasErrorMessage(notError);
+		expect(isErrorLike).toEqual(true);
+		expect(isNotErrorLike).toEqual(false);
 	});
 });


### PR DESCRIPTION
# Summary
- Test coverage for validation helper functions was too low for current standards. Improved it to 100% statement and branch coverage.
- Replaced all 'any' types for unknowns or objects according to the case, and refactored template validation typing and casting.

# Evidence
jest:
![image](https://user-images.githubusercontent.com/55909151/194267311-a335c58d-e8e5-446f-ad44-b59228bdf9c6.png)

e2e: 
![image](https://user-images.githubusercontent.com/55909151/194267184-32205130-1bf3-4a90-a2e6-a20cf8981363.png)
