### PR TITLE
UI update: removing handlebars from field name

### DIFF
--- a/cypress/e2e/exists.cy.ts
+++ b/cypress/e2e/exists.cy.ts
@@ -163,7 +163,7 @@ describe('Result JSON', () => {
 				// We extract the inner text of label without braces
 				// We extract the input value
 				// We build a MergeField object
-				return { find: label.innerText.slice(3, -3), replace: input.value };
+				return { find: label.innerText, replace: input.value };
 			});
 
 			//Assert
@@ -191,7 +191,7 @@ describe('Result JSON', () => {
 				const label = el.children[0] as HTMLLabelElement;
 				const input = el.children[1] as HTMLInputElement;
 				// We extract the inner text of label without braces and the input value
-				const find = label.innerText.slice(3, -3);
+				const find = label.innerText;
 				const replace = input.value;
 				// We build a MergeField object and return it
 				return { find, replace };
@@ -238,7 +238,7 @@ describe('Result JSON', () => {
 				// We extract the inner text of label without braces
 				// We extract the input value
 				// We build a MergeField object
-				return { find: label.innerText.slice(3, -3), replace: input.value };
+				return { find: label.innerText, replace: input.value };
 			});
 
 			// Assert

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -54,7 +54,7 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
                 class="block mb-2 monospace svelte-r93edu"
                 for="NAME"
               >
-                {{ NAME }} 
+                NAME
               </label>
                
               <input
@@ -211,7 +211,7 @@ exports[`Testing Shotstack methods Shotstack.display(), container element should
                 class="block mb-2 monospace svelte-r93edu"
                 for="NAME"
               >
-                {{ NAME }} 
+                NAME
               </label>
                
               <input
@@ -368,7 +368,7 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
                 class="block mb-2 monospace svelte-r93edu"
                 for="NAME"
               >
-                {{ NAME }} 
+                NAME
               </label>
                
               <input

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -81,7 +81,7 @@
 						{#each template.merge as { find, replace }}
 							<div data-cy="label-input">
 								<label for={find} class="block mb-2 monospace">
-									{'{{ ' + find + ' }} '}
+									{find}
 								</label>
 								<input
 									class="border w-full mb-3 pl-2 py-1 text-stone-500"


### PR DESCRIPTION
# Summary
- Removes "{{" and "}}" from form component 'find' field name
- Updates snapshots

# Evidence
e2e:
![image](https://user-images.githubusercontent.com/55909151/195241382-daca6bc3-fee5-4d01-a7b0-11d21ccc8828.png)
jest:
![image](https://user-images.githubusercontent.com/55909151/195241419-1f830c7d-8e18-402f-883e-fa83a3fadddf.png)
