### PR TITLE
Bugfix: clear on focus now correctly updates field value

### DIFF
--- a/src/lib/components/Form/fields/Add.svelte
+++ b/src/lib/components/Form/fields/Add.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import type { MergeField } from '$lib/ShotstackEditTemplate/types';
+	import { writable } from 'svelte/store';
+	import type { Writable } from 'svelte/store';
 	import AddInput from './AddInput.svelte';
-	let find = 'find';
-	let replace = 'replace';
-	function clear(target: HTMLInputElement) {
-		target.value = '';
-	}
+
+	let find = writable('find');
+	let replace = writable('replace');
+	let clear = (element: Writable<string>) => element.set('');
+
 	export let addField: (field: MergeField) => void;
 </script>
 
@@ -13,12 +15,12 @@
 	<div>
 		<h1 class="text-teal-400 px-1">Add a new merge field</h1>
 		<div class="border p-4 mb-6">
-			<AddInput bind:value={find} onFocus={clear} />
-			<AddInput bind:value={replace} onFocus={clear} />
+			<AddInput bind:value={$find} onFocus={() => clear(find)} />
+			<AddInput bind:value={$replace} onFocus={() => clear(replace)} />
 			<div class="flex flex-row-reverse">
 				<button
 					class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded align-self-end"
-					on:click|preventDefault={() => addField({ find, replace })}
+					on:click|preventDefault={() => addField({ find: $find, replace: $replace })}
 				>
 					Add
 				</button>


### PR DESCRIPTION
# Context
- Current implementation was not properly clearing out the fields on click

# Summary
- Replaced svelte variable with stores. Now the clear function updates stores by calling set with an empty string.

# Test evidence
![image](https://user-images.githubusercontent.com/55909151/195831514-5bfc2a1a-387b-4023-b495-716dad25ebef.png)
![image](https://user-images.githubusercontent.com/55909151/195831549-b591a7d1-1222-4ee1-9833-07c02541bf27.png)
