### PR TITLE
Refactor: updateResultMergeFields now updates by reference

### DIFF
--- a/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
+++ b/src/lib/ShotstackEditTemplate/ShotstackEditTemplateService.ts
@@ -63,12 +63,11 @@ export class ShotstackEditTemplateService {
 		}
 	}
 
-	updateResultMergeFields(mergeFieldInput: MergeField) {
-		const { find, replace } = mergeFieldInput;
-		const validMergeField: MergeField = { find, replace };
-		const merge = this.result.merge.map((mergeField) =>
-			mergeField?.find === mergeFieldInput.find ? validMergeField : mergeField
-		);
+	updateResultMergeFields(updatedField: MergeField, fieldReference?: MergeField) {
+		const reference = fieldReference
+			? fieldReference
+			: this.getMergeFieldItem({ find: updatedField.find });
+		const merge = this.result.merge.map((el) => (el === reference ? updatedField : el));
 		this.result = { ...this.result, merge };
 		return merge;
 	}

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -23,8 +23,8 @@
 		error = editTemplateService.error;
 	}
 
-	function handleFormInput(mergeField: { find: string; replace: string }) {
-		editTemplateService.updateResultMergeFields(mergeField);
+	function handleFormInput(mergeField: MergeField, fieldReference: MergeField) {
+		editTemplateService.updateResultMergeFields(mergeField, fieldReference);
 		result = editTemplateService.result;
 	}
 
@@ -91,7 +91,7 @@
 			</div>
 
 			<ErrorField {error} onClick={resetSourceTemplate} />
-			<Fields fields={template.merge} {handleFormInput} {addField} {removeField} {error} />
+			<Fields fields={result.merge} {handleFormInput} {addField} {removeField} {error} />
 		</form>
 
 		{#if !error}

--- a/src/lib/components/Form/fields/Fields.svelte
+++ b/src/lib/components/Form/fields/Fields.svelte
@@ -4,7 +4,7 @@
 	import Badge from './Badge.svelte';
 	export let error: Error | null;
 	export let fields: MergeField[] = [];
-	export let handleFormInput: (field: MergeField) => void;
+	export let handleFormInput: (field: MergeField, fieldReference: MergeField) => void;
 	export let addField: (field: MergeField) => void;
 	export let removeField: (field: MergeField) => void;
 </script>
@@ -23,7 +23,8 @@
 						class="border w-full mb-3 pl-2 py-1 text-stone-500"
 						type="text"
 						value={field.replace}
-						on:input={(e) => handleFormInput({ find: field.find, replace: e.currentTarget.value })}
+						on:input={(e) =>
+							handleFormInput({ find: field.find, replace: e.currentTarget.value }, field)}
 					/>
 
 					<Badge onClick={() => removeField(field)} />


### PR DESCRIPTION
# Summary
- Instead of searching for the same find prop, if a reference is provided, it will search by reference.
- If a reference is not provided, will search for the first element where the find property is equal to the find property of the updated field.
- This allows to modify find properties in the future and prevent unwanted effects.

# Test evidence
![image](https://user-images.githubusercontent.com/55909151/197469546-0d9b50f8-0269-4bde-807c-7e5be8f5b432.png)
![image](https://user-images.githubusercontent.com/55909151/197469692-85cd1aec-a3e3-483c-ba55-fedea6446a2c.png)
