### PR TITLE
Feat: adds renderElements method to main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ As to ensure the quality of the code we use ESLint as a Linter and Prettier as a
 
 ## How to implement it on your website.
 
-This module will always try to find an HTML `element` with id "shotstack-form-field", and will render the form using that `element` as a container.
-
 After downloading the released `package` from this repository you’ll be provided with three files.
 
 ```
@@ -38,35 +36,41 @@ To use provided styles: include a `<link rel="stylesheet" href="style.css">` tag
 
 ### Shotstack references
 
-|        | method      | arguments                                                           | effect                                                                                                                                                                                                                                                                                                                                           |
-| ------ | ----------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|        | constructor | initialTemplate?: any, container?: HTMLElement                      | Mounts the component with the provided template inside the container. If no initial template, Shotstack will mount with minimal data. If no container is found, it will look for an HTML element with an id of "shotstack-form-field". If this also fails, it will not render anything, and the render method will need to be called afterwards. |
-| public | renderForm  | target: HTMLElement                                                 | Renders and appends the form inside target DOM element                                                                                                                                                                                                                                                                                           |
-| public | on          | event: 'change' \| 'submit', callback: (resultTemplate) => void;    | Appends a new event handler for a specific event at the component's lifecycle                                                                                                                                                                                                                                                                    |
-| public | on          | event: 'error', callback: (error, previousError) => void;           | Appends a new event handler for the error event at the component's lifecycle                                                                                                                                                                                                                                                                     |
-| public | off         | event: 'change' \| 'submit' \| 'error', callbackReference           | Removes the callback handler from the target event handler array                                                                                                                                                                                                                                                                                 |
-| public | load        | input: any => void                                                  | Sets a new template source for the form and triggers on change events                                                                                                                                                                                                                                                                            |
-| public | submit      |                                                                     | Calls all submit event handlers (default is none)                                                                                                                                                                                                                                                                                                |
-| public | display     | none                                                                | Changes the display of the current container to show the component                                                                                                                                                                                                                                                                               |
-| public | hide        | none                                                                | Changes the display of the current container to hide the component                                                                                                                                                                                                                                                                               |
-| public | attach      | newElement: HTMLElement                                             | Changes the current container where the element should be rendered, cleaning the previous container                                                                                                                                                                                                                                              |
-| public | remove      | none                                                                | Removes the component from the container where it has been rendered                                                                                                                                                                                                                                                                              |
-| public | container   | none => HTMLElement                                                 | Returns the HTML Element where the component is being rendered                                                                                                                                                                                                                                                                                   |
-| public | addField    | find: string, replace: string => void                               | Adds a field to the source JSON template with the provided find and replace properties. Triggers change events                                                                                                                                                                                                                                   |
-| public | getField    | field: {find?: string, replace?: string} => MergeField \| undefined | Searchs for the first MergeField element with the same find and replace (if provided) properties and returns the reference. If search fails, or no properties are supplied, it returns undefined                                                                                                                                                 |
-| public | removeField | field: MergeField => void                                           | Removes provided item reference from the merge array. Triggers change events                                                                                                                                                                                                                                                                     |
-| public | merge       | none => JSON                                                        | Returns a merged JSON template to be used on the Shotstack API                                                                                                                                                                                                                                                                                   |
-| public | getInputs   | none => HTMLCollection                                              | Returns an HTMLCollection of `<input>` tags which can be used to modify and update the template JSON. On change, they trigger change events                                                                                                                                                                                                      |
+|        | method         | arguments                                                           | effect                                                                                                                                                                                           |
+| ------ | -------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|        | constructor    | initialTemplate?: any                                               | Initializes the component with the provided template. If no initial template is found, Shotstack will mount with minimal data instead.                                                           |
+| public | renderForm     | container: HTMLElement                                              | Renders and appends the form inside target HTMLElement container                                                                                                                                 |
+| public | renderElements | container: HTMLElement, after?: HTMLElement => void;                | Renders and appends an input tag for each merge field in the source template inside the container. If an 'after' HTMLElement is provided, it renders the inputs after that element instead.      |
+| public | on             | event: 'change' \| 'submit', callback: (resultTemplate) => void;    | Appends a new event handler for a specific event at the component's lifecycle                                                                                                                    |
+| public | on             | event: 'error', callback: (error, previousError) => void;           | Appends a new event handler for the error event at the component's lifecycle                                                                                                                     |
+| public | off            | event: 'change' \| 'submit' \| 'error', callbackReference           | Removes the callback handler from the target event handler array                                                                                                                                 |
+| public | load           | sourceTemplate: any => void                                         | Sets a new template source for the form and triggers on change events                                                                                                                            |
+| public | submit         | none                                                                | Calls all submit event handlers (default is none)                                                                                                                                                |
+| public | display        | none                                                                | Changes the display of the current container to show the component                                                                                                                               |
+| public | hide           | none                                                                | Changes the display of the current container to hide the component                                                                                                                               |
+| public | attach         | newElement: HTMLElement                                             | Changes the current container where the element should be rendered, cleaning the previous container                                                                                              |
+| public | remove         | none                                                                | Removes the component from the container where it has been rendered                                                                                                                              |
+| public | container      | none => HTMLElement                                                 | Returns the HTML Element where the component is being rendered                                                                                                                                   |
+| public | addField       | find: string, replace: string => void                               | Adds a field to the source JSON template with the provided find and replace properties. Triggers change events                                                                                   |
+| public | getField       | field: {find?: string, replace?: string} => MergeField \| undefined | Searchs for the first MergeField element with the same find and replace (if provided) properties and returns the reference. If search fails, or no properties are supplied, it returns undefined |
+| public | removeField    | field: MergeField => void                                           | Removes provided item reference from the merge array. Triggers change events                                                                                                                     |
+| public | merge          | none => JSON                                                        | Returns a merged JSON template to be used on the Shotstack API                                                                                                                                   |
+| public | getInputs      | none => HTMLCollection                                              | Returns an HTMLCollection of `<input>` tags which can be used to modify and update the template JSON. On change, they trigger change events                                                      |
 
-### Using Shotstack as a module import
+### Using Shotstack to generate a Form
 
-To simply implement this library as a module, on the `index.html` of your project you just have to add a new `element` where the component will be rendered on your site as follows.
+- First you have to include the library in your project either as a module or as a global variable.
+- Initialize a new instance of the library by calling `const shotstack = new Shotstack(yourSourceTemplate)`. This parameter is optional.
+- If a source template was not provided, load a source template by calling `shotstack.load(yourSourceTemplate)`.
+- Finally, render the form in a target DOM element by calling `shotstack.renderForm(targetDOMElement)`
+- Optionally, you may call the `renderElements` method instead, to generate and render a list of `<input>` for every merge element in the source template.
 
-- Create a new `<div id="shotstack-form-field"></div>`, this will be where the component will be rendered.
-- Add a `script src="./yourDirectory/Shotstack.js" type="module"` at the end of the `body` tag.
-- Optionally, you can import the Shotstack module and call the render function providing target element.
+#### Module example
 
-#### Example
+- Download and paste the package folder inside the root of your project.
+- Import Shotstack from `Shotstack.js` in your `index.js`
+
+`index.html`
 
 ```
 <!DOCTYPE html>
@@ -77,58 +81,67 @@ To simply implement this library as a module, on the `index.html` of your projec
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <-- Add component style-->
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="package/style.css">
     <title>My website</title>
 </head>
 <body>
     <h1>My app</h1>
-    ---Content of your website---
+    <!-- ---Content of your website--- -->
 
-    <--Add container, this will be the component's location-->
-    <div id="shotstack-form-field"></div>
-
+    <!-- Target container: -->
+    <div id="your-container-id">
 </body>
-<--Finally, add the provided script>
-<script src="./Shotstack.js" type="module"></script>
+<script src="./index.js" type="module"> </script>
+</html>
 </html>
 ```
 
-### Using Shotstack as a global variable
+`index.js`
 
-To implement this library as a global variable, just include the following in the `head` tag of your html `<script src="./your-directory/Shotstack.iife.js"></script>`
+```
+import Shotstack from "./package/Shotstack.js"
+const template = { merge: [{ find: "foo", replace: "baz" }] }
+const container = document.querySelector("#your-container-id")
+const shotstack = new Shotstack(template)
+shotstack.renderForm(container)
+```
 
-- Create a new `<div id="shotstack-form-field"></div>`, this will be where the component will be rendered.
-- Optionally, you can call the render function providing target element.
+#### Global variable example
 
-#### Example
+- Download and paste the package folder inside the root of your project.
+- Add a `<script src="/package/Shotstack.iife.js"></script>` tag in your `index.html`
+
+`index.html`
 
 ```
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Add component style -->
     <link rel="stylesheet" href="/package/style.css">
+    <!-- Add Shotstack as a global variable -->
     <script src="/package/Shotstack.iife.js"></script>
-
     <title>Document</title>
 </head>
-
 <body>
-    <h1>My business</h1>
-    <div id="shotstack-form-field"></div>
-    <div>
-        <script>
-            let shotstack = new Shotstack()
-        </script>
-    </div>
-</body>
+    <h1>My app</h1>
+    <!-- ---Content of your website--- -->
 
+    <!-- Target container: -->
+    <div id="your-container-id"></div>
+    <script>
+        const template = { merge: [{ find: "foo", replace: "baz" }] }
+        const container = document.querySelector("#your-container-id")
+        const shotstack = new Shotstack(template)
+        shotstack.renderForm(container)
+    </script>
+</body>
 </html>
 ```
 
 #### This is how the component will be rendered on your application.
 
-![Merge Fields Component](https://user-images.githubusercontent.com/55909151/195859063-7c87212b-be7b-484e-a835-70fda764bd2c.png)
+![Merge Fields Component](https://user-images.githubusercontent.com/55909151/197715455-8ef8070c-4cbb-4132-85fb-bbdd656269f8.png)

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -244,7 +244,7 @@ exports[`Testing Shotstack methods Shotstack.hide(), container element should ha
 
 exports[`Testing Shotstack methods Shotstack.remove(), should remove content of the container where the component is rendered on 1`] = `<div />`;
 
-exports[`Testing Shotstack module entry point Shotstack.render() should deploy the app inside target element 1`] = `
+exports[`Testing Shotstack module entry point Shotstack.renderForm() should deploy the app inside target element 1`] = `
 <div>
   <div
     class="shotstack-mergefield-form svelte-r93edu"

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -233,13 +233,461 @@ exports[`Testing Shotstack methods Shotstack.attach(), when passed a new contain
 exports[`Testing Shotstack methods Shotstack.display(), container element should have property display = "block"  1`] = `
 <div
   style="display: block;"
-/>
+>
+  <div
+    class="shotstack-mergefield-form svelte-r93edu"
+  >
+    <section
+      class="max-w-lg my-4 mx-auto border rounded-xl px-7 py-4 svelte-r93edu"
+      data-cy="form-container"
+    >
+      <form
+        class="svelte-r93edu"
+      >
+        <div
+          class="mb-6 svelte-r93edu"
+          data-cy="template-input-section"
+        >
+          <label
+            class="text-teal-400 px-1 svelte-r93edu"
+            for="json-input"
+          >
+            Paste template
+          </label>
+           
+          <textarea
+            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-r93edu"
+            data-cy="template-input"
+            id="json-input"
+          />
+        </div>
+         
+        <div
+          class="hidden"
+        >
+          <p
+            class="bg-rose-200 rounded py-2 my-4 px-4"
+            data-cy="template-input-error"
+          >
+            <span
+              class="monospace text-orange-900"
+            >
+              
+            </span>
+          </p>
+           
+          <div
+            class="flex flex-row-reverse "
+          >
+            <button
+              class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded align-self-end"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+         
+        <div>
+          <div
+            data-cy="merge-fields-input-section"
+          >
+            <h1
+              class="text-teal-400 px-1"
+            >
+              Modify Merge Values
+            </h1>
+             
+            <div
+              class="border p-4 mb-6"
+            >
+              <div
+                class="relative"
+                data-cy="label-input"
+              >
+                <label
+                  class="block mb-2 monospace"
+                  for="NAME"
+                >
+                  NAME
+                </label>
+                 
+                <input
+                  class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                  role="textbox"
+                  type="text"
+                />
+                 
+                <button
+                  class="bg-blue-400 hover:bg-blue-700 text-white font-bold absolute top-0 right-0 rounded-full w-4 h-4 p-1"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z"
+                      fill="white"
+                    />
+                  </svg>
+                </button>
+                 
+              </div>
+            </div>
+          </div>
+           
+          <div>
+            <div>
+              <h1
+                class="text-teal-400 px-1"
+              >
+                Add a new merge field
+              </h1>
+               
+              <div
+                class="border p-4 mb-6"
+              >
+                <input
+                  class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                  type="text"
+                />
+                 
+                <input
+                  class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                  type="text"
+                />
+                 
+                <div
+                  class="flex flex-row-reverse"
+                >
+                  <button
+                    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded align-self-end"
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+       
+      <div
+        class="svelte-r93edu"
+        data-cy="result-section"
+      >
+        <h1
+          class="text-teal-400 px-1 inline-block mr-2 svelte-r93edu"
+        >
+          Result
+        </h1>
+         
+        <abbr
+          class="svelte-r93edu"
+          title="Copy to clipboard"
+        >
+          <img
+            alt="copy-button"
+            class="h-4 cursor-pointer inline mb-1 svelte-r93edu"
+            src="[object Object]"
+          />
+        </abbr>
+         
+        <p
+          class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-r93edu"
+          data-cy="result"
+        >
+          {
+  "merge": [
+    {
+      "find": "NAME",
+      "replace": "world"
+    }
+  ],
+  "timeline": {
+    "tracks": [
+      {
+        "clips": [
+          {
+            "asset": {
+              "type": "title",
+              "text": "Hello {{ NAME }}",
+              "style": "future"
+            },
+            "start": 0,
+            "length": 5
+          }
+        ]
+      }
+    ]
+  },
+  "output": {
+    "format": "mp4",
+    "resolution": "hd"
+  }
+}
+        </p>
+         
+        <div
+          class="flex justify-between pt-4"
+        >
+          <a
+            class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center w-40 justify-center"
+            download="result.json"
+            href=""
+          >
+            <svg
+              class="fill-current w-4 h-4 mr-2"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z"
+              />
+            </svg>
+            
+	Download
+          </a>
+           
+          <button
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-40"
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
 `;
 
 exports[`Testing Shotstack methods Shotstack.hide(), container element should have property display = "none" 1`] = `
 <div
   style="display: none;"
-/>
+>
+  <div
+    class="shotstack-mergefield-form svelte-r93edu"
+  >
+    <section
+      class="max-w-lg my-4 mx-auto border rounded-xl px-7 py-4 svelte-r93edu"
+      data-cy="form-container"
+    >
+      <form
+        class="svelte-r93edu"
+      >
+        <div
+          class="mb-6 svelte-r93edu"
+          data-cy="template-input-section"
+        >
+          <label
+            class="text-teal-400 px-1 svelte-r93edu"
+            for="json-input"
+          >
+            Paste template
+          </label>
+           
+          <textarea
+            class="w-full h-60 monospace border p-4 overflow-auto whitespace-pre resize-none svelte-r93edu"
+            data-cy="template-input"
+            id="json-input"
+          />
+        </div>
+         
+        <div
+          class="hidden"
+        >
+          <p
+            class="bg-rose-200 rounded py-2 my-4 px-4"
+            data-cy="template-input-error"
+          >
+            <span
+              class="monospace text-orange-900"
+            >
+              
+            </span>
+          </p>
+           
+          <div
+            class="flex flex-row-reverse "
+          >
+            <button
+              class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded align-self-end"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+         
+        <div>
+          <div
+            data-cy="merge-fields-input-section"
+          >
+            <h1
+              class="text-teal-400 px-1"
+            >
+              Modify Merge Values
+            </h1>
+             
+            <div
+              class="border p-4 mb-6"
+            >
+              <div
+                class="relative"
+                data-cy="label-input"
+              >
+                <label
+                  class="block mb-2 monospace"
+                  for="NAME"
+                >
+                  NAME
+                </label>
+                 
+                <input
+                  class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                  role="textbox"
+                  type="text"
+                />
+                 
+                <button
+                  class="bg-blue-400 hover:bg-blue-700 text-white font-bold absolute top-0 right-0 rounded-full w-4 h-4 p-1"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z"
+                      fill="white"
+                    />
+                  </svg>
+                </button>
+                 
+              </div>
+            </div>
+          </div>
+           
+          <div>
+            <div>
+              <h1
+                class="text-teal-400 px-1"
+              >
+                Add a new merge field
+              </h1>
+               
+              <div
+                class="border p-4 mb-6"
+              >
+                <input
+                  class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                  type="text"
+                />
+                 
+                <input
+                  class="border w-full mb-3 pl-2 py-1 text-stone-500"
+                  type="text"
+                />
+                 
+                <div
+                  class="flex flex-row-reverse"
+                >
+                  <button
+                    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded align-self-end"
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+       
+      <div
+        class="svelte-r93edu"
+        data-cy="result-section"
+      >
+        <h1
+          class="text-teal-400 px-1 inline-block mr-2 svelte-r93edu"
+        >
+          Result
+        </h1>
+         
+        <abbr
+          class="svelte-r93edu"
+          title="Copy to clipboard"
+        >
+          <img
+            alt="copy-button"
+            class="h-4 cursor-pointer inline mb-1 svelte-r93edu"
+            src="[object Object]"
+          />
+        </abbr>
+         
+        <p
+          class="h-60 overflow-auto border p-4 whitespace-pre monospace svelte-r93edu"
+          data-cy="result"
+        >
+          {
+  "merge": [
+    {
+      "find": "NAME",
+      "replace": "world"
+    }
+  ],
+  "timeline": {
+    "tracks": [
+      {
+        "clips": [
+          {
+            "asset": {
+              "type": "title",
+              "text": "Hello {{ NAME }}",
+              "style": "future"
+            },
+            "start": 0,
+            "length": 5
+          }
+        ]
+      }
+    ]
+  },
+  "output": {
+    "format": "mp4",
+    "resolution": "hd"
+  }
+}
+        </p>
+         
+        <div
+          class="flex justify-between pt-4"
+        >
+          <a
+            class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center w-40 justify-center"
+            download="result.json"
+            href=""
+          >
+            <svg
+              class="fill-current w-4 h-4 mr-2"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z"
+              />
+            </svg>
+            
+	Download
+          </a>
+           
+          <button
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-40"
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
 `;
 
 exports[`Testing Shotstack methods Shotstack.remove(), should remove content of the container where the component is rendered on 1`] = `<div />`;

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 	window.URL.createObjectURL = jest.fn();
 });
 describe('Testing Shotstack module entry point', () => {
-	it('Shotstack.render() should deploy the app inside target element', () => {
+	it('Shotstack.renderForm() should deploy the app inside target element', () => {
 		const element = document.createElement('div');
 		const shotstackFormService = new Shotstack();
 		shotstackFormService.renderForm(element);
@@ -248,5 +248,52 @@ describe('Testing Shotstack methods', () => {
 		service.on('change', mock);
 		service.removeField(item);
 		expect(mock).toHaveBeenCalled();
+	});
+});
+
+describe('Testing Shotstack render methods', () => {
+	const merge = [
+		{ find: 'foo', replace: 'bar' },
+		{ find: 'fizz', replace: 'buzz' },
+		{ find: 'a', replace: 'b' },
+		{ find: 'b', replace: 'c' }
+	];
+	const shotstack = new Shotstack({ merge });
+	it('getInputs should return an HTMLCollection of input tags', () => {
+		const collection = shotstack.getInputs();
+		expect(collection).toBeInstanceOf(HTMLCollection);
+		const inputs = Array.from(collection);
+		inputs.forEach((input) => expect(input).toBeInstanceOf(HTMLInputElement));
+	});
+	it('For each merge field, should return an input tag with the replace value', () => {
+		const replaceValues = merge.map((key) => key.replace);
+		const collection = shotstack.getInputs();
+		Array.from<HTMLInputElement>(collection).forEach((input) =>
+			expect(replaceValues).toContain(input.value)
+		);
+	});
+	it('renderElements should render an input field for each merge field', () => {
+		const container = document.createElement('div');
+		shotstack.renderElements(container);
+		const children = container.children as HTMLCollectionOf<HTMLInputElement>;
+		const inputs = Array.from<HTMLInputElement>(children);
+		const replaceValues = shotstack.merge().merge.map((el) => el.replace);
+		expect(inputs.length).toBeGreaterThan(0);
+		expect(inputs).toHaveLength(replaceValues.length);
+		inputs.forEach((el) => expect(replaceValues).toContain(el.value));
+	});
+	it('if an after argument is provided, should render the fields after that element', () => {
+		const container = document.createElement('div');
+		const p1 = document.createElement('p');
+		const p2 = document.createElement('p');
+		const p3 = document.createElement('p');
+		container.append(p1, p2, p3);
+		shotstack.renderElements(container, p1);
+		const children = container.children;
+		expect(children.item(0)).toBe(p1);
+		expect(children.item(1)).not.toBe(p2);
+		expect(children.item(1)).toBeInstanceOf(HTMLInputElement);
+		expect(children.item(merge.length)).toBeInstanceOf(HTMLInputElement);
+		expect(children.item(merge.length + 1)).toBe(p2);
 	});
 });

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -78,14 +78,16 @@ describe('Testing Shotstack module entry point', () => {
 describe('Testing Shotstack methods', () => {
 	it('Shotstack.display(), container element should have property display = "block" ', () => {
 		const newContainer = document.createElement('div');
-		const shotstackService = new Shotstack(defaultJsonInput, newContainer);
+		const shotstackService = new Shotstack(defaultJsonInput);
+		shotstackService.renderForm(newContainer);
 		shotstackService.display();
 		expect(newContainer).toMatchSnapshot();
 	});
 
 	it('Shotstack.hide(), container element should have property display = "none"', () => {
 		const newContainer = document.createElement('div');
-		const shotstackService = new Shotstack(defaultJsonInput, newContainer);
+		const shotstackService = new Shotstack(defaultJsonInput);
+		shotstackService.renderForm(newContainer);
 		shotstackService.hide();
 		expect(newContainer).toMatchSnapshot();
 	});
@@ -95,7 +97,8 @@ describe('Testing Shotstack methods', () => {
 		previousContainer.id = 'previous-container';
 		const newContainer = document.createElement('div');
 		newContainer.id = 'new-container';
-		const shotstackService = new Shotstack(defaultJsonInput, previousContainer);
+		const shotstackService = new Shotstack(defaultJsonInput);
+		shotstackService.renderForm(previousContainer);
 		shotstackService.attach(newContainer);
 		expect(previousContainer.childNodes).toHaveLength(0);
 		expect(newContainer).toMatchSnapshot();
@@ -103,7 +106,8 @@ describe('Testing Shotstack methods', () => {
 
 	it('Shotstack.remove(), should remove content of the container where the component is rendered on', () => {
 		const newContainer = document.createElement('div');
-		const shotstackService = new Shotstack(defaultJsonInput, newContainer);
+		const shotstackService = new Shotstack(defaultJsonInput);
+		shotstackService.renderForm(newContainer);
 		shotstackService.remove();
 		expect(newContainer.childNodes).toHaveLength(0);
 		expect(newContainer).toMatchSnapshot();
@@ -111,7 +115,8 @@ describe('Testing Shotstack methods', () => {
 	it('Shotstack.container should return container where the component is being rendered on', () => {
 		const containerElement = document.createElement('div');
 		containerElement.id = 'container-element';
-		const shotstackService = new Shotstack(defaultJsonInput, containerElement);
+		const shotstackService = new Shotstack(defaultJsonInput);
+		shotstackService.renderForm(containerElement);
 		expect(shotstackService.container).toBe(containerElement);
 	});
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -30,6 +30,12 @@ class Shotstack {
 		});
 	}
 
+	renderElements(container: HTMLElement, after?: HTMLElement) {
+		const inputs = this.getInputs();
+		if (after) after.after(...inputs);
+		else container.append(...inputs);
+	}
+
 	display() {
 		if (this.container) this.container.style.display = 'block';
 	}
@@ -84,7 +90,7 @@ class Shotstack {
 					}
 				})
 		);
-		return container.children;
+		return container.children as HTMLCollectionOf<HTMLInputElement>;
 	}
 }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,9 +4,10 @@ import type { IShotstackEvents, MergeField, TemplateEvent } from './ShotstackEdi
 
 class Shotstack {
 	public templateService: ShotstackEditTemplateService;
-
-	constructor(initialTemplate?: unknown, public container?: HTMLElement) {
+	public container: HTMLElement | undefined;
+	constructor(initialTemplate?: unknown) {
 		this.templateService = new ShotstackEditTemplateService(initialTemplate);
+		this.container = undefined;
 	}
 
 	on(eventName: TemplateEvent, callback: IShotstackEvents[TemplateEvent]) {
@@ -21,7 +22,8 @@ class Shotstack {
 		this.templateService.submit();
 	}
 
-	renderForm(container: Element) {
+	renderForm(container: HTMLElement) {
+		this.container = container;
 		new Form({
 			target: container,
 			props: {

--- a/src/lib/public/README.md
+++ b/src/lib/public/README.md
@@ -4,8 +4,6 @@ Shotstack Merge Fields is a simple library that you can embed in any app. It's a
 
 ## How to implement it on your website.
 
-This module will always try to find an HTML `element` with id "shotstack-form-field", and will render the form using that `element` as a container.
-
 After downloading the released `package` from this repository you’ll be provided with three files.
 
 ```
@@ -20,35 +18,41 @@ To use provided styles: include a `<link rel="stylesheet" href="style.css">` tag
 
 ### Shotstack references
 
-|        | method      | arguments                                                           | effect                                                                                                                                                                                                                                                                                                                                           |
-| ------ | ----------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|        | constructor | initialTemplate?: any, container?: HTMLElement                      | Mounts the component with the provided template inside the container. If no initial template, Shotstack will mount with minimal data. If no container is found, it will look for an HTML element with an id of "shotstack-form-field". If this also fails, it will not render anything, and the render method will need to be called afterwards. |
-| public | renderForm  | target: HTMLElement                                                 | Renders and appends the form inside target DOM element                                                                                                                                                                                                                                                                                           |
-| public | on          | event: 'change' \| 'submit', callback: (resultTemplate) => void;    | Appends a new event handler for a specific event at the component's lifecycle                                                                                                                                                                                                                                                                    |
-| public | on          | event: 'error', callback: (error, previousError) => void;           | Appends a new event handler for the error event at the component's lifecycle                                                                                                                                                                                                                                                                     |
-| public | off         | event: 'change' \| 'submit' \| 'error', callbackReference           | Removes the callback handler from the target event handler array                                                                                                                                                                                                                                                                                 |
-| public | load        | input: any => void                                                  | Sets a new template source for the form and triggers on change events                                                                                                                                                                                                                                                                            |
-| public | submit      |                                                                     | Calls all submit event handlers (default is none)                                                                                                                                                                                                                                                                                                |
-| public | display     | none                                                                | Changes the display of the current container to show the component                                                                                                                                                                                                                                                                               |
-| public | hide        | none                                                                | Changes the display of the current container to hide the component                                                                                                                                                                                                                                                                               |
-| public | attach      | newElement: HTMLElement                                             | Changes the current container where the element should be rendered, cleaning the previous container                                                                                                                                                                                                                                              |
-| public | remove      | none                                                                | Removes the component from the container where it has been rendered                                                                                                                                                                                                                                                                              |
-| public | container   | none => HTMLElement                                                 | Returns the HTML Element where the component is being rendered                                                                                                                                                                                                                                                                                   |
-| public | addField    | find: string, replace: string => void                               | Adds a field to the source JSON template with the provided find and replace properties. Triggers change events                                                                                                                                                                                                                                   |
-| public | getField    | field: {find?: string, replace?: string} => MergeField \| undefined | Searchs for the first MergeField element with the same find and replace (if provided) properties and returns the reference. If search fails, or no properties are supplied, it returns undefined                                                                                                                                                 |
-| public | removeField | field: MergeField => void                                           | Removes provided item reference from the merge array. Triggers change events                                                                                                                                                                                                                                                                     |
-| public | merge       | none => JSON                                                        | Returns a merged JSON template to be used on the Shotstack API                                                                                                                                                                                                                                                                                   |
-| public | getInputs   | none => HTMLCollection                                              | Returns an HTMLCollection of `<input>` tags which can be used to modify and update the template JSON. On change, they trigger change events                                                                                                                                                                                                      |
+|        | method         | arguments                                                           | effect                                                                                                                                                                                           |
+| ------ | -------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|        | constructor    | initialTemplate?: any                                               | Initializes the component with the provided template. If no initial template is found, Shotstack will mount with minimal data instead.                                                           |
+| public | renderForm     | container: HTMLElement                                              | Renders and appends the form inside target HTMLElement container                                                                                                                                 |
+| public | renderElements | container: HTMLElement, after?: HTMLElement => void;                | Renders and appends an input tag for each merge field in the source template inside the container. If an 'after' HTMLElement is provided, it renders the inputs after that element instead.      |
+| public | on             | event: 'change' \| 'submit', callback: (resultTemplate) => void;    | Appends a new event handler for a specific event at the component's lifecycle                                                                                                                    |
+| public | on             | event: 'error', callback: (error, previousError) => void;           | Appends a new event handler for the error event at the component's lifecycle                                                                                                                     |
+| public | off            | event: 'change' \| 'submit' \| 'error', callbackReference           | Removes the callback handler from the target event handler array                                                                                                                                 |
+| public | load           | sourceTemplate: any => void                                         | Sets a new template source for the form and triggers on change events                                                                                                                            |
+| public | submit         | none                                                                | Calls all submit event handlers (default is none)                                                                                                                                                |
+| public | display        | none                                                                | Changes the display of the current container to show the component                                                                                                                               |
+| public | hide           | none                                                                | Changes the display of the current container to hide the component                                                                                                                               |
+| public | attach         | newElement: HTMLElement                                             | Changes the current container where the element should be rendered, cleaning the previous container                                                                                              |
+| public | remove         | none                                                                | Removes the component from the container where it has been rendered                                                                                                                              |
+| public | container      | none => HTMLElement                                                 | Returns the HTML Element where the component is being rendered                                                                                                                                   |
+| public | addField       | find: string, replace: string => void                               | Adds a field to the source JSON template with the provided find and replace properties. Triggers change events                                                                                   |
+| public | getField       | field: {find?: string, replace?: string} => MergeField \| undefined | Searchs for the first MergeField element with the same find and replace (if provided) properties and returns the reference. If search fails, or no properties are supplied, it returns undefined |
+| public | removeField    | field: MergeField => void                                           | Removes provided item reference from the merge array. Triggers change events                                                                                                                     |
+| public | merge          | none => JSON                                                        | Returns a merged JSON template to be used on the Shotstack API                                                                                                                                   |
+| public | getInputs      | none => HTMLCollection                                              | Returns an HTMLCollection of `<input>` tags which can be used to modify and update the template JSON. On change, they trigger change events                                                      |
 
-### Using Shotstack as a module import
+### Using Shotstack to generate a Form
 
-To simply implement this library as a module, on the `index.html` of your project you just have to add a new `element` where the component will be rendered on your site as follows.
+- First you have to include the library in your project either as a module or as a global variable.
+- Initialize a new instance of the library by calling `const shotstack = new Shotstack(yourSourceTemplate)`. This parameter is optional.
+- If a source template was not provided, load a source template by calling `shotstack.load(yourSourceTemplate)`.
+- Finally, render the form in a target DOM element by calling `shotstack.renderForm(targetDOMElement)`
+- Optionally, you may call the `renderElements` method instead, to generate and render a list of `<input>` for every merge element in the source template.
 
-- Create a new `<div id="shotstack-form-field"></div>`, this will be where the component will be rendered.
-- Add a `script src="./yourDirectory/Shotstack.js" type="module"` at the end of the `body` tag.
-- Optionally, you can import the Shotstack module and call the render function providing target element.
+#### Module example
 
-#### Example
+- Download and paste the package folder inside the root of your project.
+- Import Shotstack from `Shotstack.js` in your `index.js`
+
+`index.html`
 
 ```
 <!DOCTYPE html>
@@ -59,58 +63,67 @@ To simply implement this library as a module, on the `index.html` of your projec
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <-- Add component style-->
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="package/style.css">
     <title>My website</title>
 </head>
 <body>
     <h1>My app</h1>
-    ---Content of your website---
+    <!-- ---Content of your website--- -->
 
-    <--Add container, this will be the component's location-->
-    <div id="shotstack-form-field"></div>
-
+    <!-- Target container: -->
+    <div id="your-container-id">
 </body>
-<--Finally, add the provided script>
-<script src="./Shotstack.js" type="module"></script>
+<script src="./index.js" type="module"> </script>
+</html>
 </html>
 ```
 
-### Using Shotstack as a global variable
+`index.js`
 
-To implement this library as a global variable, just include the following in the `head` tag of your html `<script src="./your-directory/Shotstack.iife.js"></script>`
+```
+import Shotstack from "./package/Shotstack.js"
+const template = { merge: [{ find: "foo", replace: "baz" }] }
+const container = document.querySelector("#your-container-id")
+const shotstack = new Shotstack(template)
+shotstack.renderForm(container)
+```
 
-- Create a new `<div id="shotstack-form-field"></div>`, this will be where the component will be rendered.
-- Optionally, you can call the render function providing target element.
+#### Global variable example
 
-#### Example
+- Download and paste the package folder inside the root of your project.
+- Add a `<script src="/package/Shotstack.iife.js"></script>` tag in your `index.html`
+
+`index.html`
 
 ```
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Add component style -->
     <link rel="stylesheet" href="/package/style.css">
+    <!-- Add Shotstack as a global variable -->
     <script src="/package/Shotstack.iife.js"></script>
-
     <title>Document</title>
 </head>
-
 <body>
-    <h1>My business</h1>
-    <div id="shotstack-form-field"></div>
-    <div>
-        <script>
-            let shotstack = new Shotstack()
-        </script>
-    </div>
-</body>
+    <h1>My app</h1>
+    <!-- ---Content of your website--- -->
 
+    <!-- Target container: -->
+    <div id="your-container-id"></div>
+    <script>
+        const template = { merge: [{ find: "foo", replace: "baz" }] }
+        const container = document.querySelector("#your-container-id")
+        const shotstack = new Shotstack(template)
+        shotstack.renderForm(container)
+    </script>
+</body>
 </html>
 ```
 
 #### This is how the component will be rendered on your application.
 
-![Merge Fields Component](https://user-images.githubusercontent.com/55909151/195859063-7c87212b-be7b-484e-a835-70fda764bd2c.png)
+![Merge Fields Component](https://user-images.githubusercontent.com/55909151/197715455-8ef8070c-4cbb-4132-85fb-bbdd656269f8.png)


### PR DESCRIPTION
# Summary
- Implements a renderElements(container,after?) method, which renders the inputs from the source template into target container, or after target element if provided.
- Adds unit tests for renderElements and renderForm
- Updates Readme's to reflect latest changes
- Updates snapshots

# Evidence
![image](https://user-images.githubusercontent.com/55909151/197728003-8096fc23-19d8-4a81-9479-3ddc6d3a2b48.png)
![image](https://user-images.githubusercontent.com/55909151/197728035-9dbe17a6-dade-498f-a620-fcea64dbcc78.png)
